### PR TITLE
Added license to HelloSaga.java

### DIFF
--- a/src/main/java/com/uber/cadence/samples/hello/HelloSaga.java
+++ b/src/main/java/com/uber/cadence/samples/hello/HelloSaga.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.hello;
 
 import static com.uber.cadence.samples.common.SampleConstants.DOMAIN;


### PR DESCRIPTION
Hello!

After cloning, `./gradlew build` fails on the first try:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':checkLicenseMain'.
> License violations were found: src/main/java/com/uber/cadence/samples/hello/HelloSaga.java
```

I then ran `./gradlew licenseFormat` to generate the change seen in this PR.

That seems to have fixed the issue.