### PR TITLE
Fix datetime format for HelloSearchAttributes sample

### DIFF
--- a/src/main/java/com/uber/cadence/samples/hello/HelloSearchAttributes.java
+++ b/src/main/java/com/uber/cadence/samples/hello/HelloSearchAttributes.java
@@ -32,7 +32,7 @@ import com.uber.cadence.worker.Worker;
 import com.uber.cadence.workflow.Workflow;
 import com.uber.cadence.workflow.WorkflowMethod;
 import com.uber.cadence.workflow.WorkflowUtils;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -196,8 +196,8 @@ public class HelloSearchAttributes {
   // CustomDatetimeField takes string like "2018-07-14T17:45:55.9483536" or
   // "2019-01-01T00:00:00-08:00" as value
   private static String generateDateTimeFieldValue() {
-    LocalDateTime currentDateTime = LocalDateTime.now();
-    DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+    ZonedDateTime currentDateTime = ZonedDateTime.now();
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
     return currentDateTime.format(formatter);
   }
 }


### PR DESCRIPTION
`HelloSearchAttributes` sample was failing with error:
```
Caused by: BadRequestError(message:"2020-09-04T13:21:45.856" is not a valid search attribute value for key CustomDatetimeField)
```
LocalDateTime does not include timezone, which is seems required as indicated in code comment:
```
  // CustomDatetimeField takes string like "2018-07-14T17:45:55.9483536" or
  // "2019-01-01T00:00:00-08:00" as value
```
Instead use `ZonedDateTime` and format it with [offset](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME).