### PR TITLE
Add FeatureFlags example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 dependencies {
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
     errorprone("com.google.errorprone:error_prone_core:2.3.1")
-    compile group: 'com.uber.cadence', name: 'cadence-client', version: '3.1.0'
+    compile group: 'com.uber.cadence', name: 'cadence-client', version: '3.3.0'
     compile group: 'commons-configuration', name: 'commons-configuration', version: '1.9'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     compile group: 'com.uber.m3', name: 'tally-core', version: '0.10.0'

--- a/src/main/java/com/uber/cadence/samples/hello/HelloSignal.java
+++ b/src/main/java/com/uber/cadence/samples/hello/HelloSignal.java
@@ -19,6 +19,7 @@ package com.uber.cadence.samples.hello;
 
 import static com.uber.cadence.samples.common.SampleConstants.DOMAIN;
 
+import com.uber.cadence.FeatureFlags;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
@@ -97,7 +98,11 @@ public class HelloSignal {
     // ClientOptions.newBuilder().setRpcTimeout(5 * 1000).build();
     WorkflowClient workflowClient =
         WorkflowClient.newInstance(
-            new WorkflowServiceTChannel(ClientOptions.defaultInstance()),
+            new WorkflowServiceTChannel(
+                ClientOptions.newBuilder()
+                    .setFeatureFlags(
+                        new FeatureFlags().setWorkflowExecutionAlreadyCompletedErrorEnabled(true))
+                    .build()),
             WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build());
     // Get worker to poll the task list.
     WorkerFactory factory = WorkerFactory.newInstance(workflowClient);

--- a/src/main/java/com/uber/cadence/samples/hello/HelloSignalAndResponse.java
+++ b/src/main/java/com/uber/cadence/samples/hello/HelloSignalAndResponse.java
@@ -50,9 +50,9 @@ import java.util.Map;
 import org.apache.commons.lang.RandomStringUtils;
 
 /**
- * Demonstrates signalling a workflow, and wait until it's applied and get a
- * response. This should be much performant(lower latency) than using signal+query approach.
- * Requires a Cadence server to be running.
+ * Demonstrates signalling a workflow, and wait until it's applied and get a response. This should
+ * be much performant(lower latency) than using signal+query approach. Requires a Cadence server to
+ * be running.
  */
 @SuppressWarnings("ALL")
 public class HelloSignalAndResponse {


### PR DESCRIPTION
Adding feature flags example so customers can see how to use the feature flags.

Tried by adding another signal to HelloSignal *locally* and got this error:
```
Exception in thread "main" com.uber.cadence.client.WorkflowServiceException: WorkflowType="GreetingWorkflow::getGreetings", WorkflowExecution="WorkflowExecution(workflowId:DBvvdkwAWw, runId:e8a86db9-b42d-47e1-99e5-2465a698f002)"
        at com.uber.cadence.internal.sync.WorkflowStubImpl.signal(WorkflowStubImpl.java:101)
        at com.uber.cadence.internal.sync.WorkflowInvocationHandler$SyncWorkflowInvocationHandler.signalWorkflow(WorkflowInvocationHandler.java:273)
        at com.uber.cadence.internal.sync.WorkflowInvocationHandler$SyncWorkflowInvocationHandler.invoke(WorkflowInvocationHandler.java:252)
        at com.uber.cadence.internal.sync.WorkflowInvocationHandler.invoke(WorkflowInvocationHandler.java:164)
        at com.sun.proxy.$Proxy4.waitForName(Unknown Source)
        at com.uber.cadence.samples.hello.HelloSignal.main(HelloSignal.java:146)
**Caused by: WorkflowExecutionAlreadyCompletedError(message:workflow execution already completed)**
        at com.uber.cadence.WorkflowService$SignalWorkflowExecution_result$SignalWorkflowExecution_resultStandardScheme.read(WorkflowService.java:35720)
        at com.uber.cadence.WorkflowService$SignalWorkflowExecution_result$SignalWorkflowExecution_resultStandardScheme.read(WorkflowService.java:35652)
        at com.uber.cadence.WorkflowService$SignalWorkflowExecution_result.read(WorkflowService.java:35554)
        at org.apache.thrift.TDeserializer.deserialize(TDeserializer.java:81)
        at org.apache.thrift.TDeserializer.deserialize(TDeserializer.java:67)
        at com.uber.tchannel.messages.ThriftSerializer.decodeBody(ThriftSerializer.java:101)
        at com.uber.tchannel.messages.Serializer.decodeBody(Serializer.java:49)
        at com.uber.tchannel.messages.EncodedResponse.getBody(EncodedResponse.java:85)
        at com.uber.cadence.serviceclient.WorkflowServiceTChannel.signalWorkflowExecution(WorkflowServiceTChannel.java:1408)
        at com.uber.cadence.serviceclient.WorkflowServiceTChannel.lambda$SignalWorkflowExecution$25(WorkflowServiceTChannel.java:1395)
        at com.uber.cadence.serviceclient.WorkflowServiceTChannel.lambda$measureRemoteProc$2(WorkflowServiceTChannel.java:389)
        at com.uber.cadence.serviceclient.WorkflowServiceTChannel.measureRemoteCall(WorkflowServiceTChannel.java:362)
        at com.uber.cadence.serviceclient.WorkflowServiceTChannel.measureRemoteProc(WorkflowServiceTChannel.java:386)
        at com.uber.cadence.serviceclient.WorkflowServiceTChannel.SignalWorkflowExecution(WorkflowServiceTChannel.java:1394)
        at com.uber.cadence.internal.external.GenericWorkflowClientExternalImpl.lambda$signalWorkflowExecution$2(GenericWorkflowClientExternalImpl.java:273)
        at com.uber.cadence.internal.common.RpcRetryer.lambda$retry$0(RpcRetryer.java:113)
        at com.uber.cadence.internal.common.RpcRetryer.retryWithResult(RpcRetryer.java:135)
        at com.uber.cadence.internal.common.RpcRetryer.retry(RpcRetryer.java:110)
        at com.uber.cadence.internal.common.RpcRetryer.retry(RpcRetryer.java:119)
        at com.uber.cadence.internal.external.GenericWorkflowClientExternalImpl.signalWorkflowExecution(GenericWorkflowClientExternalImpl.java:273)
        at com.uber.cadence.internal.sync.WorkflowStubImpl.signal(WorkflowStubImpl.java:99)
```