### PR TITLE
Add sample to get exception from continueAsNew run

### DIFF
--- a/src/main/java/com/uber/cadence/samples/hello/HelloContinueAsNewException.java
+++ b/src/main/java/com/uber/cadence/samples/hello/HelloContinueAsNewException.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.hello;
+
+import static com.uber.cadence.samples.common.SampleConstants.DOMAIN;
+
+import com.google.common.base.Throwables;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.client.WorkflowException;
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactory;
+import com.uber.cadence.workflow.Workflow;
+import com.uber.cadence.workflow.WorkflowMethod;
+
+/**
+ * Demonstrates how to get exception after ContinueAsNew
+ *
+ * <p>Requires a local instance of Cadence server to be running.
+ */
+public class HelloContinueAsNewException {
+
+  static final String TASK_LIST = "HelloContinueAsNewException";
+
+  public interface GreetingWorkflow {
+    /**
+     * Use single fixed ID to ensure that there is at most one instance running. To run multiple
+     * instances set different IDs through WorkflowOptions passed to the
+     * WorkflowClient.newWorkflowStub call.
+     */
+    @WorkflowMethod(executionStartToCloseTimeoutSeconds = 300, taskList = TASK_LIST)
+    void getGreeting(String name, boolean canThrow);
+  }
+
+  public static class GreetingWorkflowImpl implements GreetingWorkflow {
+
+    /**
+     * ContinueAsNew Stub is used to terminate this workflow run and create the next one with the
+     * same ID atomically.
+     */
+    private final GreetingWorkflow continueAsNew =
+        Workflow.newContinueAsNewStub(GreetingWorkflow.class);
+
+    @Override
+    public void getGreeting(String name, boolean canThrow) {
+      if (canThrow) {
+        throw new RuntimeException(name);
+      }
+
+      // Current workflow run stops executing after this call.
+      continueAsNew.getGreeting(name, true);
+      // unreachable line
+    }
+  }
+
+  public static void main(String[] args) throws InterruptedException {
+    // Get a new client
+    // NOTE: to set a different options, you can do like this:
+    // ClientOptions.newBuilder().setRpcTimeout(5 * 1000).build();
+    WorkflowClient workflowClient =
+        WorkflowClient.newInstance(
+            new WorkflowServiceTChannel(ClientOptions.defaultInstance()),
+            WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build());
+    // Get worker to poll the task list.
+    WorkerFactory factory = WorkerFactory.newInstance(workflowClient);
+    Worker worker = factory.newWorker(TASK_LIST);
+    // Workflows are stateful. So you need a type to create instances.
+    worker.registerWorkflowImplementationTypes(GreetingWorkflowImpl.class);
+    // Start listening to the workflow and activity task lists.
+    factory.start();
+
+    GreetingWorkflow workflow = workflowClient.newWorkflowStub(GreetingWorkflow.class);
+    try {
+      workflow.getGreeting("World", false);
+    } catch (WorkflowException e) {
+      System.out.println("\nStack Trace:\n" + Throwables.getStackTraceAsString(e));
+      System.exit(1);
+    }
+  }
+}


### PR DESCRIPTION
```
Stack Trace:
com.uber.cadence.client.WorkflowFailureException: WorkflowType="GreetingWorkflow::getGreeting", WorkflowID="64c080b5-f8a6-4739-b2c5-28ec54413a3b", RunID="c5684578-9fc6-4ff5-9413-4bbd5905d6a0, WorkflowType="GreetingWorkflow::getGreeting", WorkflowExecution="WorkflowExecution(workflowId:64c080b5-f8a6-4739-b2c5-28ec54413a3b, runId:c5684578-9fc6-4ff5-9413-4bbd5905d6a0)"
	at com.uber.cadence.internal.sync.WorkflowStubImpl.mapToWorkflowFailureException(WorkflowStubImpl.java:391)
	at com.uber.cadence.internal.sync.WorkflowStubImpl.getResult(WorkflowStubImpl.java:319)
	at com.uber.cadence.internal.sync.WorkflowStubImpl.getResult(WorkflowStubImpl.java:287)
	at com.uber.cadence.internal.sync.WorkflowInvocationHandler$SyncWorkflowInvocationHandler.startWorkflow(WorkflowInvocationHandler.java:289)
	at com.uber.cadence.internal.sync.WorkflowInvocationHandler$SyncWorkflowInvocationHandler.invoke(WorkflowInvocationHandler.java:248)
	at com.uber.cadence.internal.sync.WorkflowInvocationHandler.invoke(WorkflowInvocationHandler.java:164)
	at com.sun.proxy.$Proxy2.getGreeting(Unknown Source)
	at com.uber.cadence.samples.hello.HelloContinueAsNewException.main(HelloContinueAsNewException.java:91)
Caused by: java.lang.RuntimeException: World
	at com.uber.cadence.samples.hello.HelloContinueAsNewException$GreetingWorkflowImpl.getGreeting(HelloContinueAsNewException.java:64)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method:0)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.uber.cadence.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:246)
	at com.uber.cadence.internal.sync.WorkflowRunnable.run(WorkflowRunnable.java:47)
	at com.uber.cadence.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102)
	at com.uber.cadence.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:99)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)


```