### PR TITLE
Update the errorprone library to build with gradle out of the box

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
-    errorprone("com.google.errorprone:error_prone_core:2.3.1")
+    errorprone("com.google.errorprone:error_prone_core:2.4.0")
     compile group: 'com.uber.cadence', name: 'cadence-client', version: '3.5.0'
     compile group: 'commons-configuration', name: 'commons-configuration', version: '1.9'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'


### PR DESCRIPTION
I had trouble compiling the samples out of the box. Here's what I did:

```
> git clone https://github.com/uber/cadence-java-samples 
> cd cadence-java-samples 

> ./gradlew --version

------------------------------------------------------------
Gradle 6.8.3
------------------------------------------------------------

Build time:   2021-02-22 16:13:28 UTC
Revision:     9e26b4a9ebb910eaa1b8da8ff8575e514bc61c78

Kotlin:       1.4.20
Groovy:       2.5.12
Ant:          Apache Ant(TM) version 1.10.9 compiled on September 27 2020
JVM:          11.0.13 (Amazon.com Inc. 11.0.13+8-LTS)
OS:           Mac OS X 12.0.1 x86_64
```

Then building I receive this error:
```

```