### PR TITLE
Added Spring application example for worker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,14 @@ To run:
 
     ./gradlew -q execute -PmainClass=com.uber.cadence.samples.bookingsaga.TripBookingSaga
 
+### Sprint Boot Application
 
+Example of how to start a cadence worker service using Spring Boot Framework
+
+To run:
+
+    # Start Cadence Server
+    # see https://github.com/uber/cadence/tree/master/docker
+    # register domain
+    ./gradlew -q execute -PmainClass=com.uber.cadence.samples.common.RegisterDomain
+    ./gradlew -q execute -PmainClass=com.uber.cadence.samples.spring.CadenceSamplesApplication

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,14 @@ plugins {
     id 'net.minecrell.licenser' version '0.4.1'
     id "com.github.sherter.google-java-format" version "0.9"
     id "net.ltgt.errorprone" version "1.3.0"
+    id 'org.springframework.boot' version '2.7.15'
+
 }
 
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'com.github.sherter.google-java-format'
+apply plugin: 'io.spring.dependency-management'
 
 googleJavaFormat {
     toolVersion '1.5'
@@ -46,6 +49,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     testCompile group: 'org.powermock', name: 'powermock-api-mockito', version: '1.7.3'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 compileJava {

--- a/src/main/java/com/uber/cadence/samples/spring/CadenceSamplesApplication.java
+++ b/src/main/java/com/uber/cadence/samples/spring/CadenceSamplesApplication.java
@@ -1,0 +1,32 @@
+package com.uber.cadence.samples.spring;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.samples.spring.workflows.HelloWorldWorkflow;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class CadenceSamplesApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(CadenceSamplesApplication.class, args);
+  }
+
+  // Example to start a workflow
+  @Bean
+  public CommandLineRunner startHelloWorkflow(ApplicationContext ctx) {
+    return args -> {
+      System.out.println("Start one synchronous HelloWorld workflow");
+
+      WorkflowClient workflowClient = ctx.getBean(WorkflowClient.class);
+      HelloWorldWorkflow stub = workflowClient.newWorkflowStub(HelloWorldWorkflow.class);
+      stub.sayHello(new SampleMessage("hello"));
+
+      System.out.println("Synchronous HelloWorld workflow finished");
+      System.exit(SpringApplication.exit(ctx, () -> 0));
+    };
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
+++ b/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
@@ -1,0 +1,39 @@
+package com.uber.cadence.samples.spring.cadence;
+
+import static com.uber.cadence.samples.common.SampleConstants.DOMAIN;
+import static com.uber.cadence.samples.spring.common.Constant.TASK_LIST;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.samples.spring.workflows.HelloWorldWorkflowImpl;
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactory;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+
+@Configuration
+public class CadenceAutoConfiguration {
+  @Bean
+  public WorkflowClient workflowClient() {
+    return WorkflowClient.newInstance(
+        new WorkflowServiceTChannel(ClientOptions.defaultInstance()),
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build());
+  }
+
+  @EventListener(ApplicationStartedEvent.class)
+  public void startWorker(ApplicationStartedEvent event) {
+    System.out.println("Starting workers");
+
+    ApplicationContext context = event.getApplicationContext();
+    WorkflowClient workflowClient = context.getBean(WorkflowClient.class);
+    WorkerFactory factory = WorkerFactory.newInstance(workflowClient);
+    Worker worker = factory.newWorker(TASK_LIST);
+    worker.registerWorkflowImplementationTypes(HelloWorldWorkflowImpl.class);
+    factory.start();
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/spring/common/Constant.java
+++ b/src/main/java/com/uber/cadence/samples/spring/common/Constant.java
@@ -1,0 +1,5 @@
+package com.uber.cadence.samples.spring.common;
+
+public class Constant {
+  public static final String TASK_LIST = "cadence-samples-worker";
+}

--- a/src/main/java/com/uber/cadence/samples/spring/models/SampleMessage.java
+++ b/src/main/java/com/uber/cadence/samples/spring/models/SampleMessage.java
@@ -1,0 +1,13 @@
+package com.uber.cadence.samples.spring.models;
+
+public class SampleMessage {
+  String message;
+
+  public SampleMessage(String message) {
+    this.message = message;
+  }
+
+  public String GetMessage() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/HelloWorldWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/HelloWorldWorkflow.java
@@ -1,0 +1,15 @@
+package com.uber.cadence.samples.spring.workflows;
+
+import static com.uber.cadence.samples.spring.common.Constant.TASK_LIST;
+
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.workflow.WorkflowMethod;
+
+public interface HelloWorldWorkflow {
+  @WorkflowMethod(
+    executionStartToCloseTimeoutSeconds = 10,
+    taskStartToCloseTimeoutSeconds = 10,
+    taskList = TASK_LIST
+  )
+  String sayHello(SampleMessage message);
+}

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/HelloWorldWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/HelloWorldWorkflowImpl.java
@@ -1,0 +1,18 @@
+package com.uber.cadence.samples.spring.workflows;
+
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.workflow.Workflow;
+import org.slf4j.Logger;
+
+public class HelloWorldWorkflowImpl implements HelloWorldWorkflow {
+  private final Logger logger = Workflow.getLogger(HelloWorldWorkflowImpl.class);
+
+  @Override
+  public String sayHello(SampleMessage message) {
+    logger.info("executing HelloWorldWorkflow::sayHello");
+
+    String result = "Hello, " + message.GetMessage();
+    logger.info("output: " + result);
+    return result;
+  }
+}


### PR DESCRIPTION
**Changes**

Added example on how to create spring application for worker service

**Test**

After cadence server container is up,

./gradlew -q execute -PmainClass=com.uber.cadence.samples.common.RegisterDomain
./gradlew -q execute -PmainClass=com.uber.cadence.samples.spring.CadenceSamplesApplication


The output looks like
```
1:17:10 PM: Executing 'execute -q -PmainClass=com.uber.cadence.samples.spring.CadenceSamplesApplication'...


  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::               (v2.7.15)

13:17:16.981 [main] INFO  c.u.c.s.s.CadenceSamplesApplication - Starting CadenceSamplesApplication using Java 1.8.0_192 on shengs-C02XN3VDJGH6 with PID 48745 (/Users/shengs/code/cadence-java-samples/build/classes/java/main started by shengs in /Users/shengs/code/cadence-java-samples)
13:17:16.986 [main] INFO  c.u.c.s.s.CadenceSamplesApplication - No active profile set, falling back to 1 default profile: "default"
13:17:18.004 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8080 (http)
13:17:18.013 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
13:17:18.016 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
13:17:18.016 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.79]
13:17:18.166 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
13:17:18.167 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1127 ms
13:17:18.486 [main] INFO  c.u.c.s.WorkflowServiceTChannel - Initialized TChannel for service cadence-frontend, LibraryVersion: 3.7.2, FeatureVersion: 1.5.0
13:17:18.929 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
13:17:18.948 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8080 (http) with context path ''
13:17:18.957 [main] INFO  c.u.c.s.s.CadenceSamplesApplication - Started CadenceSamplesApplication in 2.357 seconds (JVM running for 2.832)
Starting workers
Start one synchronous HelloWorld workflow
13:17:19.578 [workflow-root] INFO  c.u.c.s.s.w.HelloWorldWorkflowImpl - executing HelloWorldWorkflow::sayHello
13:17:19.579 [workflow-root] INFO  c.u.c.s.s.w.HelloWorldWorkflowImpl - output: Hello, hello
Synchronous HelloWorld workflow finished
13:17:19.703 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Pausing ProtocolHandler ["http-nio-8080"]
13:17:19.703 [main] INFO  o.a.catalina.core.StandardService - Stopping service [Tomcat]
13:17:19.707 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Stopping ProtocolHandler ["http-nio-8080"]
13:17:19.708 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Destroying ProtocolHandler ["http-nio-8080"]
```