### PR TITLE
Add signal samples

### DIFF
--- a/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
+++ b/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
@@ -5,7 +5,8 @@ import static com.uber.cadence.samples.spring.common.Constant.TASK_LIST;
 
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
-import com.uber.cadence.samples.spring.workflows.HelloWorldWorkflowImpl;
+import com.uber.cadence.samples.spring.workflows.impl.HelloWorldWorkflowImpl;
+import com.uber.cadence.samples.spring.workflows.impl.SignalWorkflowImpl;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
 import com.uber.cadence.worker.Worker;
@@ -33,7 +34,12 @@ public class CadenceAutoConfiguration {
     WorkflowClient workflowClient = context.getBean(WorkflowClient.class);
     WorkerFactory factory = WorkerFactory.newInstance(workflowClient);
     Worker worker = factory.newWorker(TASK_LIST);
+
+    // HelloWorldWorkflow registration
     worker.registerWorkflowImplementationTypes(HelloWorldWorkflowImpl.class);
+
+    // SignalWorkflow registration
+    worker.registerWorkflowImplementationTypes(SignalWorkflowImpl.class);
     factory.start();
   }
 }

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/SignalWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/SignalWorkflow.java
@@ -1,0 +1,16 @@
+package com.uber.cadence.samples.spring.workflows;
+
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.workflow.SignalMethod;
+import com.uber.cadence.workflow.WorkflowMethod;
+
+public interface SignalWorkflow {
+  @WorkflowMethod
+  void getGreeting(SampleMessage sampleMessage);
+
+  @SignalMethod
+  void waitForGreeting(String greeting);
+
+  @SignalMethod
+  void cancel();
+}

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/HelloWorldWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/HelloWorldWorkflowImpl.java
@@ -1,6 +1,7 @@
-package com.uber.cadence.samples.spring.workflows;
+package com.uber.cadence.samples.spring.workflows.impl;
 
 import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.samples.spring.workflows.HelloWorldWorkflow;
 import com.uber.cadence.workflow.Workflow;
 import org.slf4j.Logger;
 

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
@@ -8,26 +8,33 @@ import org.slf4j.Logger;
 public class SignalWorkflowImpl implements SignalWorkflow {
   private final Logger logger = Workflow.getLogger(SignalWorkflowImpl.class);
   private String name;
-  private String greetingMsg;
+  private String greetingMsg = "";
   private boolean cancel = false;
 
   @Override
   public void getGreeting(SampleMessage sampleMessage) {
     logger.info("executing SignalWorkflow::getGreeting");
     this.name = sampleMessage.GetMessage();
-    Workflow.await(
-        () -> {
-          if (cancel) {
-            logger.info("SignalWorkflow cancelled");
-          }
-          logger.info("greeting: " + this.greetingMsg);
-          return cancel;
-        });
-    logger.info("greeting:" + this.greetingMsg);
+    int count = 0;
+
+    while (!cancel) {
+      Workflow.await(() -> cancel || !this.greetingMsg.isEmpty());
+      if (!this.greetingMsg.isEmpty()) {
+        logger.info(++count + ": " + this.greetingMsg + "!");
+        this.greetingMsg = "";
+      }
+    }
+
+    logger.info("workflow canceled");
   }
 
   @Override
   public void waitForGreeting(String greeting) {
+    if (cancel) {
+      logger.info("signal workflow failed because it is already cancelled");
+      return;
+    }
+
     logger.info("received signal from SignalWorkflow:waitForName");
     this.greetingMsg = String.format("%s, %s!", greeting, this.name);
   }

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
@@ -8,25 +8,28 @@ import org.slf4j.Logger;
 public class SignalWorkflowImpl implements SignalWorkflow {
   private final Logger logger = Workflow.getLogger(SignalWorkflowImpl.class);
   private String name;
+  private String greetingMsg;
   private boolean cancel = false;
 
   @Override
   public void getGreeting(SampleMessage sampleMessage) {
     logger.info("executing SignalWorkflow::getGreeting");
     this.name = sampleMessage.GetMessage();
-    while (true) {
-      Workflow.await(() -> cancel);
-      if (cancel) {
-        logger.info("SignalWorkflow cancelled");
-        return;
-      }
-    }
+    Workflow.await(
+        () -> {
+          if (cancel) {
+            logger.info("SignalWorkflow cancelled");
+          }
+          logger.info("greeting: " + this.greetingMsg);
+          return cancel;
+        });
+    logger.info("greeting:" + this.greetingMsg);
   }
 
   @Override
   public void waitForGreeting(String greeting) {
     logger.info("received signal from SignalWorkflow:waitForName");
-    logger.info(greeting + " " + name + "!");
+    this.greetingMsg = String.format("%s, %s!", greeting, this.name);
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
@@ -1,0 +1,36 @@
+package com.uber.cadence.samples.spring.workflows.impl;
+
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.samples.spring.workflows.SignalWorkflow;
+import com.uber.cadence.workflow.Workflow;
+import org.slf4j.Logger;
+
+public class SignalWorkflowImpl implements SignalWorkflow {
+  private final Logger logger = Workflow.getLogger(SignalWorkflowImpl.class);
+  private String name;
+  private boolean cancel = false;
+
+  @Override
+  public void getGreeting(SampleMessage sampleMessage) {
+    logger.info("executing SignalWorkflow::getGreeting");
+    this.name = sampleMessage.GetMessage();
+    while (true) {
+      Workflow.await(() -> cancel);
+      if (cancel) {
+        logger.info("SignalWorkflow cancelled");
+        return;
+      }
+    }
+  }
+
+  @Override
+  public void waitForGreeting(String greeting) {
+    logger.info("received signal from SignalWorkflow:waitForName");
+    logger.info(greeting + " " + name + "!");
+  }
+
+  @Override
+  public void cancel() {
+    this.cancel = true;
+  }
+}


### PR DESCRIPTION
Add a new simple Cadence sample for Signal workflow.

To run the signal workflow, try the following CLI.
`cadence --env development --domain samples-domain workflow start --tl cadence-samples-worker --et 6000 --workflow_type SignalWorkflow::getGreeting --input '{"message":"uber"}'`
This CLI should give you a workflow ID in return in the terminal.

Then use this workflow ID and pass a payload to the signal via
`cadence --env development --domain samples-domain workflow signal --workflow_id 47b2b165-2f7d-4cbd-bc3a-910f2d748d87 --name  SignalWorkflow::waitForGreeting --input '"Hello"`

You should see a log printed out in the terminal. You may change the input payload to see different greeting message.

The workflow will keep alive until you invoke the cancel signal.
`cadence --env development --domain samples-domain workflow signal --workflow_id <YOUR WORKFLOW ID> --name  SignalWorkflow::cancel --input ''`
The workflow should be in `Completed` status after cancellation. 

Also, split interface definition and implementation into two separate package as it is the Spring Boot tradition to do so. 