### PR TITLE
Add continueAsNew mechanism to cadence java sample

### DIFF
--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
@@ -3,6 +3,7 @@ package com.uber.cadence.samples.spring.workflows.impl;
 import com.uber.cadence.samples.spring.models.SampleMessage;
 import com.uber.cadence.samples.spring.workflows.SignalWorkflow;
 import com.uber.cadence.workflow.Workflow;
+import java.util.Optional;
 import org.slf4j.Logger;
 
 public class SignalWorkflowImpl implements SignalWorkflow {
@@ -22,6 +23,16 @@ public class SignalWorkflowImpl implements SignalWorkflow {
       if (!this.greetingMsg.isEmpty()) {
         logger.info(++count + ": " + this.greetingMsg + "!");
         this.greetingMsg = "";
+
+        // A workflow execution cannot receive infinite number of signals due to history limit
+        // By default 10000 is MaximumSignalsPerExecution which can be configured by DynamicConfig of Cadence cluster.
+        // But it's recommended to do continueAsNew after receiving certain number of signals.
+        // in production, use a number <1000.
+        if (count == 3) {
+          Workflow.continueAsNew(
+              Optional.of("SignalWorkflow::getGreeting"), Optional.empty(), sampleMessage);
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
Users of signal workflows should limit the number of signals sent to an open workflow. Therefore, it is recommended to keep track of how many signals are sent. In this example, a continueAsNew method can be used to refresh the counter. 

The continueAsNew method take three arguments - workflow type name, workflow options and the workflow input payload. 