### PR TITLE
fix workflow registration, also add copyright header

### DIFF
--- a/src/main/java/com/uber/cadence/samples/spring/CadenceSamplesApplication.java
+++ b/src/main/java/com/uber/cadence/samples/spring/CadenceSamplesApplication.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring;
 
 import com.uber.cadence.client.WorkflowClient;

--- a/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
+++ b/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring.cadence;
 
 import static com.uber.cadence.samples.common.SampleConstants.DOMAIN;
@@ -35,11 +52,8 @@ public class CadenceAutoConfiguration {
     WorkerFactory factory = WorkerFactory.newInstance(workflowClient);
     Worker worker = factory.newWorker(TASK_LIST);
 
-    // HelloWorldWorkflow registration
-    worker.registerWorkflowImplementationTypes(HelloWorldWorkflowImpl.class);
-
-    // SignalWorkflow registration
-    worker.registerWorkflowImplementationTypes(SignalWorkflowImpl.class);
+    worker.registerWorkflowImplementationTypes(
+        HelloWorldWorkflowImpl.class, SignalWorkflowImpl.class);
     factory.start();
   }
 }

--- a/src/main/java/com/uber/cadence/samples/spring/common/Constant.java
+++ b/src/main/java/com/uber/cadence/samples/spring/common/Constant.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring.common;
 
 public class Constant {

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/HelloWorldWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/HelloWorldWorkflow.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring.workflows;
 
 import static com.uber.cadence.samples.spring.common.Constant.TASK_LIST;

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/SignalWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/SignalWorkflow.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring.workflows;
 
 import com.uber.cadence.samples.spring.models.SampleMessage;

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/HelloWorldWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/HelloWorldWorkflowImpl.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring.workflows.impl;
 
 import com.uber.cadence.samples.spring.models.SampleMessage;

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/SignalWorkflowImpl.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.samples.spring.workflows.impl;
 
 import com.uber.cadence.samples.spring.models.SampleMessage;


### PR DESCRIPTION
The workflow registration function takes a varag argument so calling the function multiple times will override the previous call.