### PR TITLE
 Add child workflow implementation under the new worker config

### DIFF
--- a/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
+++ b/src/main/java/com/uber/cadence/samples/spring/cadence/CadenceAutoConfiguration.java
@@ -22,7 +22,9 @@ import static com.uber.cadence.samples.spring.common.Constant.TASK_LIST;
 
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.samples.spring.workflows.impl.ChildWorkflowImpl;
 import com.uber.cadence.samples.spring.workflows.impl.HelloWorldWorkflowImpl;
+import com.uber.cadence.samples.spring.workflows.impl.ParentWorkflowImpl;
 import com.uber.cadence.samples.spring.workflows.impl.SignalWorkflowImpl;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
@@ -53,7 +55,10 @@ public class CadenceAutoConfiguration {
     Worker worker = factory.newWorker(TASK_LIST);
 
     worker.registerWorkflowImplementationTypes(
-        HelloWorldWorkflowImpl.class, SignalWorkflowImpl.class);
+        HelloWorldWorkflowImpl.class,
+        SignalWorkflowImpl.class,
+        ParentWorkflowImpl.class,
+        ChildWorkflowImpl.class);
     factory.start();
   }
 }

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/ChildWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/ChildWorkflow.java
@@ -1,0 +1,8 @@
+package com.uber.cadence.samples.spring.workflows;
+
+import com.uber.cadence.workflow.WorkflowMethod;
+
+public interface ChildWorkflow {
+  @WorkflowMethod
+  String greetInChild(String msg);
+}

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/ParentWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/ParentWorkflow.java
@@ -1,0 +1,11 @@
+package com.uber.cadence.samples.spring.workflows;
+
+import static com.uber.cadence.samples.spring.common.Constant.TASK_LIST;
+
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.workflow.WorkflowMethod;
+
+public interface ParentWorkflow {
+  @WorkflowMethod(executionStartToCloseTimeoutSeconds = 10, taskList = TASK_LIST)
+  String getGreetingInParent(SampleMessage sampleMessage);
+}

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/ChildWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/ChildWorkflowImpl.java
@@ -1,0 +1,10 @@
+package com.uber.cadence.samples.spring.workflows.impl;
+
+import com.uber.cadence.samples.spring.workflows.ChildWorkflow;
+
+public class ChildWorkflowImpl implements ChildWorkflow {
+  @Override
+  public String greetInChild(String msg) {
+    return "Hello, " + msg + "!";
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/spring/workflows/impl/ParentWorkflowImpl.java
+++ b/src/main/java/com/uber/cadence/samples/spring/workflows/impl/ParentWorkflowImpl.java
@@ -1,0 +1,15 @@
+package com.uber.cadence.samples.spring.workflows.impl;
+
+import com.uber.cadence.samples.spring.models.SampleMessage;
+import com.uber.cadence.samples.spring.workflows.ChildWorkflow;
+import com.uber.cadence.samples.spring.workflows.ParentWorkflow;
+import com.uber.cadence.workflow.Workflow;
+
+public class ParentWorkflowImpl implements ParentWorkflow {
+  @Override
+  public String getGreetingInParent(SampleMessage sampleMessage) {
+    // Workflows are stateful. So a new stub must be created for each new child.
+    ChildWorkflow childWorkflow = Workflow.newChildWorkflowStub(ChildWorkflow.class);
+    return childWorkflow.greetInChild(sampleMessage.GetMessage());
+  }
+}


### PR DESCRIPTION
To start a parent workflow, try
`cadence --env development --domain samples-domain workflow start --workflow_type ParentWorkflow::getGreetingInParent --et 60 --tl cadence-samples-worker --input '{"message":"Uber"}'`

To start the child workflow in standalone style, try
`cadence --env development --domain samples-domain workflow start --workflow_type ChildWorkflow::greetInChild --et 60 --tl cadence-samples-worker --input '"Uber"'`
