### PR TITLE
[CDNC-7884] Gradle build GitHub action 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,6 @@
 name: Build cadence-java-samples
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   build-gradle-project:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,21 @@
+name: Build cadence-java-samples
+
+on: [ push ]
+
+jobs:
+  build-gradle-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Run build with Gradle Wrapper
+        run: ./gradlew build


### PR DESCRIPTION
Implementing a Github action to build using the included gradle wrapper.

It will run on every push to this repository, ensuring that the build is not broken.

You can see a run of this action here: https://github.com/ibarrajo/cadence-java-samples/actions/runs/8162988546/job/22315204599

<img width="485" alt="image" src="https://github.com/uber/cadence-java-samples/assets/1480657/b3d9c40e-7f37-428d-b62b-3f3a2b0bc5f9">
