### PR TITLE
Added more continue as new cases for Non-Determinism java checks

### DIFF
--- a/src/test/java/com/uber/cadence/samples/replaytests/HelloPeriodicReplayTest.java
+++ b/src/test/java/com/uber/cadence/samples/replaytests/HelloPeriodicReplayTest.java
@@ -41,9 +41,19 @@ public class HelloPeriodicReplayTest {
 
   // Continue as new case: If frequency is changed to lesser number.
   // FAIL As expected: It should hit non-determinism case and it is hitting properly.
+  //  @Test
+  //  public void testReplay_continueAsNew_lessFrequency() throws Exception {
+  //    WorkflowReplayer.replayWorkflowExecutionFromResource(
+  //        "replaytests/HelloPeriodic.json",
+  // HelloPeriodic_lessFrequency.GreetingWorkflowImpl.class);
+  //  }
+
+  // Continue as new case: when continue as new has child workflow as well
+  //EXPECTED: FAIL   ACTUAL: FAIL
 //  @Test
-//  public void testReplay_continueAsNew_lessFrequency() throws Exception {
+//  public void testReplay_continueAsNew_withChildWorkflows() throws Exception {
 //    WorkflowReplayer.replayWorkflowExecutionFromResource(
-//        "replaytests/HelloPeriodic.json", HelloPeriodic_lessFrequency.GreetingWorkflowImpl.class);
+//        "replaytests/HelloPeriodic.json",
+//        HelloPeriodic_withChildWorkflows.GreetingWorkflowImpl.class);
 //  }
 }


### PR DESCRIPTION
Added tests for continue as new workflows for following cases:
1) When more frequency of continue as new
    EXPECTED: FAIL
    ACTUAL: PASS
 
 2) When frequency is 1-9
      EXPECTED: FAIL
      ACTUAL: FAIL
      but when we increase value more but less than actual definition's frequency, it passes.
      
  3) When continue as new has a child workflow which is not expected
       EXPECTED: FAIL
       ACTUAL: FAIL
