### PR TITLE
feat: add Custom Workflow Controls (Markdoc query) samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ These samples demonstrate various capabilities of Java Cadence client and server
     the result to a destination. The first activity can be picked up by any worker. However, the second and third activities
     must be executed on the same host as the first one.
 
+* **Custom Workflow Controls** ([`com.uber.cadence.samples.query`](src/main/java/com/uber/cadence/samples/query/)) — workflow queries that return **markdown** for Cadence Web (Markdoc buttons that **signal** workflows or **start** new workflows). **Requires Cadence Web v4.0.14+.** Copy-paste run instructions: [query samples README](src/main/java/com/uber/cadence/samples/query/README.md).
+
 ## Get the Samples
 
 Run the following commands:
@@ -79,6 +81,8 @@ top right corner from "Open" to "Closed" to see the list of the completed workfl
 Click on a *RUN ID* of a workflow to see more details about it. Try different view formats to get a different level of
 details about the execution history.
 
+For **query responses rendered as markdown** (Custom Workflow Controls), use **Cadence Web v4.0.14 or newer** and follow the [query samples README](src/main/java/com/uber/cadence/samples/query/README.md).
+
 ## Install Cadence CLI
 
 [Command Line Interface Documentation](https://mfateev.github.io/cadence/docs/08_cli)
@@ -118,7 +122,23 @@ execute together, we recommend that you run more than one instance of this worke
 The second command starts workflows. Each invocation starts a new workflow execution.
 
     ./gradlew -q execute -PmainClass=com.uber.cadence.samples.fileprocessing.FileProcessingStarter
-    
+
+### Custom Workflow Controls (Markdoc query responses)
+
+These samples need **Cadence Web v4.0.14+**. Run a **worker** in one terminal, then a **starter** in another. See [src/main/java/com/uber/cadence/samples/query/README.md](src/main/java/com/uber/cadence/samples/query/README.md) for full copy-paste steps.
+
+Worker (task list `query`):
+
+    ./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.QueryWorker
+
+Starters (pick one per run):
+
+    ./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.MarkdownQueryStarter
+    ./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.LunchVoteStarter
+    ./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.OrderFulfillmentStarter
+
+In Cadence Web, open the workflow → **Query** tab → run query **`Signal`**, **`options`**, or **`dashboard`** (matching the starter you used).
+
 ### Trip Booking
 
 Cadence implementation of the [Camunda BPMN trip booking example](https://github.com/berndruecker/trip-booking-saga-java)

--- a/src/main/java/com/uber/cadence/samples/query/LunchVoteStarter.java
+++ b/src/main/java/com/uber/cadence/samples/query/LunchVoteStarter.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowOptions;
+import java.time.Duration;
+import java.util.UUID;
+
+/** Starts a {@link LunchVoteWorkflow} execution. Use Cadence Web Query tab → options. */
+public final class LunchVoteStarter {
+
+  private LunchVoteStarter() {}
+
+  public static void main(String[] args) {
+    try {
+      WorkflowClient workflowClient = QuerySampleSupport.newWorkflowClient();
+
+      WorkflowOptions options =
+          new WorkflowOptions.Builder()
+              .setTaskList(QueryConstants.TASK_LIST)
+              .setExecutionStartToCloseTimeout(Duration.ofMinutes(12))
+              .setWorkflowId("lunch-vote-" + UUID.randomUUID())
+              .build();
+
+      LunchVoteWorkflow.WorkflowIface workflow =
+          workflowClient.newWorkflowStub(LunchVoteWorkflow.WorkflowIface.class, options);
+
+      // Starts the workflow asynchronously — the starter can exit immediately.
+      WorkflowClient.start(workflow::run);
+      System.out.println(
+          "Started LunchVoteWorkflow. In Cadence Web (v4.0.14+), open the run, Query tab → options.");
+      System.exit(0);
+    } catch (RuntimeException e) {
+      if (QuerySampleSupport.printHintIfDomainMissing(e)) {
+        System.exit(1);
+      }
+      throw e;
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/LunchVoteWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/LunchVoteWorkflow.java
@@ -1,0 +1,200 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import static com.uber.cadence.samples.query.QueryConstants.CLUSTER;
+import static com.uber.cadence.samples.query.QueryConstants.DOMAIN;
+import static com.uber.cadence.samples.query.QueryConstants.TASK_LIST;
+
+import com.uber.cadence.workflow.QueryMethod;
+import com.uber.cadence.workflow.SignalMethod;
+import com.uber.cadence.workflow.Workflow;
+import com.uber.cadence.workflow.WorkflowMethod;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Demonstrates interactive voting via Cadence Web (v4.0.14+). Signals accumulate votes and the
+ * query named {@code options} renders current results and vote buttons as markdown.
+ */
+public final class LunchVoteWorkflow {
+
+  private LunchVoteWorkflow() {}
+
+  /**
+   * Signal payload for a lunch vote. Public fields are required so Cadence's JSON data converter
+   * can deserialize the signal input. Field names must match the JSON keys in the Markdoc
+   * {@code input=} attribute (e.g. {@code input={"location":"Farmhouse","meal":"Red Thai Curry"}}).
+   */
+  public static class LunchOrder {
+    public String location;
+    public String meal;
+    public String requests;
+
+    /** No-arg constructor required for JSON deserialization. */
+    public LunchOrder() {}
+
+    public LunchOrder(String location, String meal, String requests) {
+      this.location = location;
+      this.meal = meal;
+      this.requests = requests;
+    }
+  }
+
+  /**
+   * The voting pattern: the workflow method keeps the execution open for a voting window, signals
+   * mutate state (accumulate votes), and the query reads that state to render the current results.
+   */
+  public interface WorkflowIface {
+
+    @WorkflowMethod(
+        name = QueryConstants.LUNCH_VOTE_WORKFLOW_TYPE,
+        executionStartToCloseTimeoutSeconds = 700,
+        taskList = TASK_LIST)
+    void run();
+
+    /** Visible as "options" in the Cadence Web Query dropdown. */
+    @QueryMethod(name = "options")
+    MarkdownFormattedResponse optionsQuery();
+
+    /**
+     * {@code name} sets the signal type string the worker listens for. It must match the
+     * {@code signalName} attribute in the Markdoc template so Cadence Web sends the right signal.
+     */
+    @SignalMethod(name = "lunch_order")
+    void lunchOrder(LunchOrder vote);
+  }
+
+  public static final class WorkflowImpl implements WorkflowIface {
+
+    private final List<LunchOrder> votes = new ArrayList<>();
+
+    /** Cached on the workflow thread; queries must not call {@link Workflow#getWorkflowInfo()}. */
+    private String cachedWorkflowId = "";
+
+    private String cachedRunId = "";
+
+    @Override
+    public void run() {
+      cachedWorkflowId = Workflow.getWorkflowInfo().getWorkflowId();
+      cachedRunId = Workflow.getWorkflowInfo().getRunId();
+      // Keep the workflow open for the voting period. Votes arrive via the lunchOrder signal
+      // while the workflow sleeps; Workflow.sleep is interruptible by signals.
+      Workflow.sleep(Duration.ofMinutes(10));
+    }
+
+    @Override
+    public MarkdownFormattedResponse optionsQuery() {
+      String workflowId = cachedWorkflowId;
+      String runId = cachedRunId;
+      String voteTable = makeLunchVoteTable(votes);
+      String menuTable = makeLunchMenu();
+
+      String data =
+          "\n## Lunch Options\n\n"
+              + "We're voting on where to order lunch today. Select the option you want to vote for.\n\n"
+              + "---\n\n"
+              + "### Current Votes\n\n"
+              + voteTable
+              + "\n"
+              + "### Menu Options\n\n"
+              + menuTable
+              + "\n\n---\n\n"
+              + "### Cast Your Vote\n\n"
+              + signalBlock(
+                  workflowId,
+                  runId,
+                  "Farmhouse - Red Thai Curry",
+                  "{\"location\":\"Farmhouse\",\"meal\":\"Red Thai Curry\",\"requests\":\"spicy\"}")
+              + signalBlock(
+                  workflowId,
+                  runId,
+                  "Ethiopian Wat",
+                  "{\"location\":\"Ethiopian\",\"meal\":\"Wat with Injera\",\"requests\":\"\"}")
+              + signalBlock(
+                  workflowId,
+                  runId,
+                  "Ler Ros - Tofu Bahn Mi",
+                  "{\"location\":\"Ler Ros\",\"meal\":\"Tofu Bahn Mi\",\"requests\":\"\"}")
+              + "\n{% br /%}\n\n"
+              + "*Vote closes when workflow times out (10 minutes)*\n\t";
+
+      return new MarkdownFormattedResponse(data);
+    }
+
+    /** Builds a Markdoc {@code {%- signal -%}} tag. Every attribute is required for Cadence Web
+     *  to route the signal to the correct workflow execution. */
+    private static String signalBlock(
+        String workflowId, String runId, String label, String jsonInput) {
+      return "{% signal \n"
+          + "\tsignalName=\"lunch_order\" \n"
+          + "\tlabel=\""
+          + label
+          + "\"\n"
+          + "\tdomain=\""
+          + DOMAIN
+          + "\"\n"
+          + "\tcluster=\""
+          + CLUSTER
+          + "\"\n"
+          + "\tworkflowId=\""
+          + workflowId
+          + "\"\n"
+          + "\trunId=\""
+          + runId
+          + "\"\n"
+          + "\tinput="
+          + jsonInput
+          + "\n/%}\n";
+    }
+
+    @Override
+    public void lunchOrder(LunchOrder vote) {
+      votes.add(vote);
+    }
+
+    private static String makeLunchVoteTable(List<LunchOrder> votes) {
+      if (votes.isEmpty()) {
+        return "| Location | Meal | Requests |\n|----------|------|----------|\n| *No votes yet* | | |\n";
+      }
+      StringBuilder table = new StringBuilder();
+      table.append("| Location | Meal | Requests |\n|----------|------|----------|\n");
+      for (LunchOrder vote : votes) {
+        table
+            .append("| ")
+            .append(vote.location != null ? vote.location : "")
+            .append(" | ")
+            .append(vote.meal != null ? vote.meal : "")
+            .append(" | ")
+            .append(vote.requests != null ? vote.requests : "")
+            .append(" |\n");
+      }
+      return table.toString();
+    }
+
+    private static String makeLunchMenu() {
+      return "| Picture | Description |\n"
+          + "|---------|-------------|\n"
+          + "| {% image src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Red_roast_duck_curry.jpg/200px-Red_roast_duck_curry.jpg\" alt=\"Red Thai Curry\" width=\"200\" /%} | **Farmhouse - Red Thai Curry**: A dish in Thai cuisine made from curry paste, coconut milk, meat, seafood, vegetables, and herbs. |\n"
+          + "| {% image src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/B%C3%A1nh_m%C3%AC_th%E1%BB%8Bt_n%C6%B0%E1%BB%9Bng.png/200px-B%C3%A1nh_m%C3%AC_th%E1%BB%8Bt_n%C6%B0%E1%BB%9Bng.png\" alt=\"Tofu Bahn Mi\" width=\"200\" /%} | **Ler Ros - Tofu Bahn Mi**: A Vietnamese sandwich with a baguette filled with lemongrass tofu, vegetables, and fresh herbs. |\n"
+          + "| {% image src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Ethiopian_wat.jpg/960px-Ethiopian_wat.jpg\" alt=\"Ethiopian Wat\" width=\"200\" /%} | **Ethiopian Wat**: A traditional Ethiopian stew made from spices, vegetables, and legumes, served with injera flatbread. |\n"
+          + "\n*(source: wikipedia)*";
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/LunchVoteWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/LunchVoteWorkflow.java
@@ -85,9 +85,7 @@ public final class LunchVoteWorkflow {
 
     private final List<LunchOrder> votes = new ArrayList<>();
 
-    /** Cached on the workflow thread; queries must not call {@link Workflow#getWorkflowInfo()}. */
     private String cachedWorkflowId = "";
-
     private String cachedRunId = "";
 
     @Override

--- a/src/main/java/com/uber/cadence/samples/query/MarkdownFormattedResponse.java
+++ b/src/main/java/com/uber/cadence/samples/query/MarkdownFormattedResponse.java
@@ -17,6 +17,9 @@
 
 package com.uber.cadence.samples.query;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * The JSON shape Cadence Web (v4.0.14+) expects for formatted query responses. When a {@link
  * com.uber.cadence.workflow.QueryMethod} returns this object, the default data converter serializes
@@ -40,14 +43,27 @@ public final class MarkdownFormattedResponse {
   private final String data;
 
   /**
+   * Constructor for JSON deserialization (e.g. Java clients using the Cadence SDK data converter).
+   * A no-arg constructor cannot populate {@code private final} fields; {@code @JsonCreator} with
+   * explicit properties is required.
+   */
+  @JsonCreator
+  private MarkdownFormattedResponse(
+      @JsonProperty("cadenceResponseType") String cadenceResponseType,
+      @JsonProperty("format") String format,
+      @JsonProperty("data") String data) {
+    this.cadenceResponseType = cadenceResponseType;
+    this.format = format;
+    this.data = data;
+  }
+
+  /**
    * @param markdownData the markdown string to render in Cadence Web. May include Markdoc tags such
    *     as {@code {%- signal -%}} and {@code {%- start -%}}.
    */
   public MarkdownFormattedResponse(String markdownData) {
     // These two values are the required constants that Cadence Web checks for.
-    this.cadenceResponseType = "formattedData";
-    this.format = "text/markdown";
-    this.data = markdownData;
+    this("formattedData", "text/markdown", markdownData);
   }
 
   public String getCadenceResponseType() {

--- a/src/main/java/com/uber/cadence/samples/query/MarkdownFormattedResponse.java
+++ b/src/main/java/com/uber/cadence/samples/query/MarkdownFormattedResponse.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+/**
+ * The JSON shape Cadence Web (v4.0.14+) expects for formatted query responses. When a {@link
+ * com.uber.cadence.workflow.QueryMethod} returns this object, the default data converter serializes
+ * it to:
+ *
+ * <pre>{@code
+ * {
+ *   "cadenceResponseType": "formattedData",
+ *   "format": "text/markdown",
+ *   "data": "<your markdown string>"
+ * }
+ * }</pre>
+ *
+ * Cadence Web detects this shape and renders the {@code data} field as markdown (with Markdoc
+ * extensions) instead of displaying raw JSON.
+ */
+public final class MarkdownFormattedResponse {
+
+  private final String cadenceResponseType;
+  private final String format;
+  private final String data;
+
+  /**
+   * @param markdownData the markdown string to render in Cadence Web. May include Markdoc tags such
+   *     as {@code {%- signal -%}} and {@code {%- start -%}}.
+   */
+  public MarkdownFormattedResponse(String markdownData) {
+    // These two values are the required constants that Cadence Web checks for.
+    this.cadenceResponseType = "formattedData";
+    this.format = "text/markdown";
+    this.data = markdownData;
+  }
+
+  public String getCadenceResponseType() {
+    return cadenceResponseType;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public String getData() {
+    return data;
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/MarkdownQueryStarter.java
+++ b/src/main/java/com/uber/cadence/samples/query/MarkdownQueryStarter.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowOptions;
+import java.time.Duration;
+import java.util.UUID;
+
+/** Starts a {@link MarkdownQueryWorkflow} execution (async). Use Cadence Web Query tab → Signal. */
+public final class MarkdownQueryStarter {
+
+  private MarkdownQueryStarter() {}
+
+  public static void main(String[] args) {
+    try {
+      WorkflowClient workflowClient = QuerySampleSupport.newWorkflowClient();
+
+      WorkflowOptions options =
+          new WorkflowOptions.Builder()
+              .setTaskList(QueryConstants.TASK_LIST)
+              .setExecutionStartToCloseTimeout(Duration.ofHours(1))
+              .setWorkflowId("markdown-query-" + UUID.randomUUID())
+              .build();
+
+      MarkdownQueryWorkflow.WorkflowIface workflow =
+          workflowClient.newWorkflowStub(MarkdownQueryWorkflow.WorkflowIface.class, options);
+
+      // Starts the workflow asynchronously — the starter can exit immediately.
+      WorkflowClient.start(workflow::run);
+      System.out.println(
+          "Started MarkdownQueryWorkflow. In Cadence Web (v4.0.14+), open the run, Query tab → Signal.");
+      System.exit(0);
+    } catch (RuntimeException e) {
+      if (QuerySampleSupport.printHintIfDomainMissing(e)) {
+        System.exit(1);
+      }
+      throw e;
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/MarkdownQueryWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/MarkdownQueryWorkflow.java
@@ -93,17 +93,11 @@ public final class MarkdownQueryWorkflow {
     private boolean hasCompleteSignal;
     private boolean completeFlag;
 
-    /**
-     * Query handlers run on a different thread in the Java SDK and must not call {@link
-     * Workflow#getWorkflowInfo()} or {@link Workflow#currentTimeMillis()}. Cache these on the
-     * workflow thread in {@link #run()}.
-     */
     private String cachedWorkflowId = "";
-
     private String cachedRunId = "";
 
-    /** Suggested id for {% start %}; refreshed on the workflow thread after each activity. */
-    private String suggestedNewWorkflowId = "markdown-pending";
+    /** Set by {@link #refreshSuggestedStartWorkflowId()} in {@code run()} before any query executes. */
+    private String suggestedNewWorkflowId = "";
 
     @Override
     public void run() {

--- a/src/main/java/com/uber/cadence/samples/query/MarkdownQueryWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/MarkdownQueryWorkflow.java
@@ -1,0 +1,212 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import static com.uber.cadence.samples.query.QueryConstants.CLUSTER;
+import static com.uber.cadence.samples.query.QueryConstants.DOMAIN;
+import static com.uber.cadence.samples.query.QueryConstants.TASK_LIST;
+
+import com.uber.cadence.activity.ActivityMethod;
+import com.uber.cadence.activity.ActivityOptions;
+import com.uber.cadence.workflow.QueryMethod;
+import com.uber.cadence.workflow.SignalMethod;
+import com.uber.cadence.workflow.Workflow;
+import com.uber.cadence.workflow.WorkflowMethod;
+import java.time.Duration;
+
+/**
+ * Demonstrates a workflow whose query response is interactive markdown rendered by Cadence Web
+ * (v4.0.14+). The query named {@code Signal} returns Markdoc with buttons that can signal this
+ * workflow or start a new one.
+ */
+public final class MarkdownQueryWorkflow {
+
+  private MarkdownQueryWorkflow() {}
+
+  /**
+   * Workflow contract combining all three Cadence interaction patterns used in this sample:
+   *
+   * <ul>
+   *   <li>{@code @WorkflowMethod} — the entry point; loops waiting for signals.
+   *   <li>{@code @QueryMethod} — returns a {@link MarkdownFormattedResponse} so Cadence Web
+   *       renders interactive markdown instead of raw JSON.
+   *   <li>{@code @SignalMethod} — receives external input (from Markdoc buttons or the CLI).
+   * </ul>
+   */
+  public interface WorkflowIface {
+
+    @WorkflowMethod(
+        name = QueryConstants.MARKDOWN_QUERY_WORKFLOW_TYPE,
+        executionStartToCloseTimeoutSeconds = 3600,
+        taskList = TASK_LIST)
+    void run();
+
+    /**
+     * The {@code name} attribute sets the query type visible in the Cadence Web "Query" dropdown.
+     * Users select "Signal" and click Run to see the markdown.
+     */
+    @QueryMethod(name = "Signal")
+    MarkdownFormattedResponse signalQuery();
+
+    /**
+     * Receives the "complete" / "continue" signal from Markdoc buttons. {@code true} means finish
+     * the workflow; {@code false} means continue looping.
+     *
+     * <p>The Markdoc {@code signalName} must use the qualified form {@link
+     * QueryConstants#MARKDOWN_QUERY_COMPLETE_SIGNAL_MARKDOC} ({@code WorkflowIface::complete})
+     * because the Java SDK registers signals as {@code InterfaceName::methodName} by default.
+     */
+    @SignalMethod
+    void complete(boolean value);
+  }
+
+  public interface MarkdownQueryActivities {
+    @ActivityMethod(scheduleToCloseTimeoutSeconds = 3600)
+    String markdownQueryActivity(boolean complete);
+  }
+
+  public static final class WorkflowImpl implements WorkflowIface {
+
+    private final MarkdownQueryActivities activities =
+        Workflow.newActivityStub(
+            MarkdownQueryActivities.class,
+            new ActivityOptions.Builder()
+                .setScheduleToStartTimeout(Duration.ofHours(1))
+                .setStartToCloseTimeout(Duration.ofHours(1))
+                .build());
+
+    private boolean hasCompleteSignal;
+    private boolean completeFlag;
+
+    /**
+     * Query handlers run on a different thread in the Java SDK and must not call {@link
+     * Workflow#getWorkflowInfo()} or {@link Workflow#currentTimeMillis()}. Cache these on the
+     * workflow thread in {@link #run()}.
+     */
+    private String cachedWorkflowId = "";
+
+    private String cachedRunId = "";
+
+    /** Suggested id for {% start %}; refreshed on the workflow thread after each activity. */
+    private String suggestedNewWorkflowId = "markdown-pending";
+
+    @Override
+    public void run() {
+      cacheExecutionIds();
+      refreshSuggestedStartWorkflowId();
+
+      // Signal-wait-activity loop:
+      //  1. Block until a signal arrives (Complete or Continue).
+      //  2. Run an activity to acknowledge the signal.
+      //  3. If the signal was "complete" (true), exit; otherwise loop back.
+      while (true) {
+        Workflow.await(() -> hasCompleteSignal);
+        hasCompleteSignal = false;
+        activities.markdownQueryActivity(completeFlag);
+        refreshSuggestedStartWorkflowId();
+        if (completeFlag) {
+          return;
+        }
+      }
+    }
+
+    private void cacheExecutionIds() {
+      cachedWorkflowId = Workflow.getWorkflowInfo().getWorkflowId();
+      cachedRunId = Workflow.getWorkflowInfo().getRunId();
+    }
+
+    private void refreshSuggestedStartWorkflowId() {
+      suggestedNewWorkflowId = "markdown-" + Workflow.currentTimeMillis();
+    }
+
+    @Override
+    public MarkdownFormattedResponse signalQuery() {
+      String workflowId = cachedWorkflowId;
+      String runId = cachedRunId;
+      String newWorkflowId = suggestedNewWorkflowId;
+
+      // Build the markdown string using Markdoc tags that Cadence Web renders as interactive
+      // controls:
+      //   {% signal %}  — button that sends a signal to a running workflow
+      //   {% start %}   — button that starts a new workflow execution
+      //   {% br %}      — line break
+      //   {% image %}   — inline image
+      // Each tag requires domain, workflowId, and runId so Cadence Web targets the right
+      // execution.
+      String data =
+          "\n\t## Markdown Query Workflow\n\t\n\t"
+              + "You can use markdown as your query response, which also supports starting and signaling workflows.\n\t\n\t"
+              + "* Use the Complete button to complete this workflow.\n\t"
+              + "* Use the Continue button just to send a signal to continue this workflow.\n\t"
+              + "* Or you can use the \"Start Another\" button to start another workflow of this type.\n\t\n\t"
+              + "{% signal \n\t\tsignalName=\""
+              + QueryConstants.MARKDOWN_QUERY_COMPLETE_SIGNAL_MARKDOC
+              + "\" \n\t\tlabel=\"Complete\"\n\t\tdomain=\""
+              + DOMAIN
+              + "\"\n\t\tcluster=\""
+              + CLUSTER
+              + "\"\n\t\tworkflowId=\""
+              + workflowId
+              + "\"\n\t\trunId=\""
+              + runId
+              + "\"\n\t\tinput=true\n\t/%}\n\t"
+              + "{% signal\n\t\tsignalName=\""
+              + QueryConstants.MARKDOWN_QUERY_COMPLETE_SIGNAL_MARKDOC
+              + "\" \n\t\tlabel=\"Continue\"\n\t\tdomain=\""
+              + DOMAIN
+              + "\"\n\t\tcluster=\""
+              + CLUSTER
+              + "\"\n\t\tworkflowId=\""
+              + workflowId
+              + "\"\n\t\trunId=\""
+              + runId
+              + "\"\n\t\tinput=false\n\t/%}\n\t"
+              + "{% start\n\t\tworkflowType=\""
+              + QueryConstants.MARKDOWN_QUERY_WORKFLOW_TYPE
+              + "\" \n\t\tlabel=\"Start Another\"\n\t\tdomain=\""
+              + DOMAIN
+              + "\"\n\t\tcluster=\""
+              + CLUSTER
+              + "\"\n\t\ttaskList=\""
+              + TASK_LIST
+              + "\"\n\t\tworkflowId=\""
+              + newWorkflowId
+              + "\"\n\t\ttimeoutSeconds=60\n\t/%}\n\t\n\t"
+              + "{% br /%} \n\t"
+              + "{% image src=\"https://cadenceworkflow.io/img/cadence-logo.svg\" alt=\"Cadence Logo\" height=\"100\" /%}\n\t\t";
+
+      return new MarkdownFormattedResponse(data);
+    }
+
+    @Override
+    public void complete(boolean value) {
+      this.completeFlag = value;
+      this.hasCompleteSignal = true;
+    }
+  }
+
+  public static final class MarkdownQueryActivitiesImpl implements MarkdownQueryActivities {
+    @Override
+    public String markdownQueryActivity(boolean complete) {
+      if (complete) {
+        return "Workflow will complete now";
+      }
+      return "Workflow will continue to run";
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentModels.java
+++ b/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentModels.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+/** Domain model and signal payloads for {@link OrderFulfillmentWorkflow}. */
+public final class OrderFulfillmentModels {
+
+  private OrderFulfillmentModels() {}
+
+  /*
+   * Order state machine transitions:
+   *
+   *   pending_payment ──► payment_approved ──► ready_to_ship ──► shipped ──► delivered
+   *        │                    │                                   │
+   *        ▼                    ▼                                   ▼
+   *    cancelled            refunded                            refunded
+   */
+  public static final String STATUS_PENDING_PAYMENT = "pending_payment";
+  public static final String STATUS_PAYMENT_APPROVED = "payment_approved";
+  public static final String STATUS_READY_TO_SHIP = "ready_to_ship";
+  public static final String STATUS_SHIPPED = "shipped";
+  public static final String STATUS_DELIVERED = "delivered";
+  public static final String STATUS_CANCELLED = "cancelled";
+  public static final String STATUS_REFUNDED = "refunded";
+
+  /**
+   * Mutable workflow state held in memory. Cadence replays the event history on recovery to
+   * reconstruct this object, so it does not need to be persisted externally.
+   */
+  public static class Order {
+    public String orderID = "ORD-2024-001234";
+    public String customerName = "Alice Johnson";
+    public String customerEmail = "alice.johnson@example.com";
+    public OrderItem[] items =
+        new OrderItem[] {
+          new OrderItem("Wireless Headphones", 2, 79.99),
+          new OrderItem("Phone Case", 1, 19.99),
+        };
+    public double totalAmount = 179.97;
+    public String status = STATUS_PENDING_PAYMENT;
+    public String trackingNum = "";
+    public String carrier = "";
+    public double refundAmount;
+    public String refundReason = "";
+    public long createdAtMillis;
+  }
+
+  public static class OrderItem {
+    public String name;
+    public int quantity;
+    public double price;
+
+    public OrderItem() {}
+
+    public OrderItem(String name, int quantity, double price) {
+      this.name = name;
+      this.quantity = quantity;
+      this.price = price;
+    }
+  }
+
+  public static class ActionLogEntry {
+    public long timestampMillis;
+    public String action;
+    public String operator;
+    public String details;
+  }
+
+  /**
+   * Signal POJOs below use public fields so the Cadence JSON data converter can deserialize them.
+   * Field names must match the JSON keys in each Markdoc {@code input=} attribute; for example
+   * {@code input={"operator":"admin","reason":"Fraud"}} maps to {@link #operator} and
+   * {@link #reason}.
+   */
+  public static class RejectPaymentSignal {
+    public String reason;
+    public String operator;
+  }
+
+  public static class ApprovePaymentSignal {
+    public String operator;
+  }
+
+  public static class ShipOrderSignal {
+    public String trackingNumber;
+    public String carrier;
+    public String operator;
+  }
+
+  public static class RefundSignal {
+    public double amount;
+    public String reason;
+    public String operator;
+  }
+
+  public static class CancelOrderSignal {
+    public String reason;
+    public String operator;
+  }
+
+  public static class SimpleSignal {
+    public String operator;
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentModels.java
+++ b/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentModels.java
@@ -26,9 +26,11 @@ public final class OrderFulfillmentModels {
    * Order state machine transitions:
    *
    *   pending_payment ──► payment_approved ──► ready_to_ship ──► shipped ──► delivered
-   *        │                    │                                   │
-   *        ▼                    ▼                                   ▼
-   *    cancelled            refunded                            refunded
+   *        │                    │                    │               │
+   *        ▼                    ▼                    ▼               ▼
+   *    cancelled            refunded            cancelled        refunded
+   *
+   *   pending_payment → cancelled is via reject_payment (not cancel_order).
    */
   public static final String STATUS_PENDING_PAYMENT = "pending_payment";
   public static final String STATUS_PAYMENT_APPROVED = "payment_approved";

--- a/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentStarter.java
+++ b/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentStarter.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowOptions;
+import java.time.Duration;
+import java.util.UUID;
+
+/** Starts an {@link OrderFulfillmentWorkflow} execution. Use Cadence Web Query tab → dashboard. */
+public final class OrderFulfillmentStarter {
+
+  private OrderFulfillmentStarter() {}
+
+  public static void main(String[] args) {
+    try {
+      WorkflowClient workflowClient = QuerySampleSupport.newWorkflowClient();
+
+      WorkflowOptions options =
+          new WorkflowOptions.Builder()
+              .setTaskList(QueryConstants.TASK_LIST)
+              .setExecutionStartToCloseTimeout(Duration.ofHours(1))
+              .setWorkflowId("order-fulfillment-" + UUID.randomUUID())
+              .build();
+
+      OrderFulfillmentWorkflow.WorkflowIface workflow =
+          workflowClient.newWorkflowStub(OrderFulfillmentWorkflow.WorkflowIface.class, options);
+
+      // Starts the workflow asynchronously — the starter can exit immediately.
+      WorkflowClient.start(workflow::run);
+      System.out.println(
+          "Started OrderFulfillmentWorkflow. In Cadence Web (v4.0.14+), open the run, Query tab → dashboard.");
+      System.exit(0);
+    } catch (RuntimeException e) {
+      if (QuerySampleSupport.printHintIfDomainMissing(e)) {
+        System.exit(1);
+      }
+      throw e;
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentWorkflow.java
@@ -107,8 +107,8 @@ public final class OrderFulfillmentWorkflow {
      */
     private final ArrayDeque<Object> inbox = new ArrayDeque<>();
 
-    private final String cachedWorkflowId = "";
-    private final String cachedRunId = "";
+    private final String cachedWorkflowId;
+    private final String cachedRunId;
 
     /** Inbox wrapper so {@code mark_ready_to_ship} vs {@code mark_delivered} are not ambiguous. */
     private static final class ReadyToShipMessage {

--- a/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentWorkflow.java
@@ -1,0 +1,598 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_CANCELLED;
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_DELIVERED;
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_PAYMENT_APPROVED;
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_PENDING_PAYMENT;
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_READY_TO_SHIP;
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_REFUNDED;
+import static com.uber.cadence.samples.query.OrderFulfillmentModels.STATUS_SHIPPED;
+import static com.uber.cadence.samples.query.QueryConstants.CLUSTER;
+import static com.uber.cadence.samples.query.QueryConstants.DOMAIN;
+import static com.uber.cadence.samples.query.QueryConstants.TASK_LIST;
+
+import com.uber.cadence.workflow.QueryMethod;
+import com.uber.cadence.workflow.SignalMethod;
+import com.uber.cadence.workflow.Workflow;
+import com.uber.cadence.workflow.WorkflowMethod;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Demonstrates a state-machine workflow where the Markdoc query named {@code dashboard} acts as an
+ * ops admin panel in Cadence Web (v4.0.14+). Buttons change based on order status, and each signal
+ * drives a state transition.
+ */
+public final class OrderFulfillmentWorkflow {
+
+  private OrderFulfillmentWorkflow() {}
+
+  /**
+   * Dashboard pattern: one query method renders the full markdown UI (tables, status, action
+   * buttons), and multiple signal methods drive state transitions on the order. The {@code name}
+   * on each {@code @SignalMethod} must match the {@code signalName} in the Markdoc template;
+   * without {@code name}, the Java SDK would default to {@code WorkflowIface::methodName}.
+   */
+  public interface WorkflowIface {
+
+    @WorkflowMethod(
+        name = QueryConstants.ORDER_FULFILLMENT_WORKFLOW_TYPE,
+        executionStartToCloseTimeoutSeconds = 3600,
+        taskList = TASK_LIST)
+    void run();
+
+    /** Visible as "dashboard" in the Cadence Web Query dropdown. */
+    @QueryMethod(name = "dashboard")
+    MarkdownFormattedResponse dashboardQuery();
+
+    @SignalMethod(name = "approve_payment")
+    void approvePayment(OrderFulfillmentModels.ApprovePaymentSignal signal);
+
+    @SignalMethod(name = "reject_payment")
+    void rejectPayment(OrderFulfillmentModels.RejectPaymentSignal signal);
+
+    @SignalMethod(name = "mark_ready_to_ship")
+    void markReadyToShip(OrderFulfillmentModels.SimpleSignal signal);
+
+    @SignalMethod(name = "ship_order")
+    void shipOrder(OrderFulfillmentModels.ShipOrderSignal signal);
+
+    @SignalMethod(name = "issue_refund")
+    void issueRefund(OrderFulfillmentModels.RefundSignal signal);
+
+    @SignalMethod(name = "cancel_order")
+    void cancelOrder(OrderFulfillmentModels.CancelOrderSignal signal);
+
+    @SignalMethod(name = "mark_delivered")
+    void markDelivered(OrderFulfillmentModels.SimpleSignal signal);
+  }
+
+  public static final class WorkflowImpl implements WorkflowIface {
+
+    private static final DateTimeFormatter CREATED_FMT =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter HISTORY_TIME_FMT =
+        DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneOffset.UTC);
+
+    private final OrderFulfillmentModels.Order order = new OrderFulfillmentModels.Order();
+    private final List<OrderFulfillmentModels.ActionLogEntry> actionLog = new ArrayList<>();
+
+    /**
+     * Inbox for signal-to-main-loop communication. Signal handlers (which execute on the workflow
+     * thread but outside the main loop) enqueue messages here. The main {@link #run()} loop
+     * drains the inbox one message at a time, keeping state transitions sequential and
+     * deterministic.
+     */
+    private final ArrayDeque<Object> inbox = new ArrayDeque<>();
+
+    /** Cached in constructor (workflow thread); queries must not call {@link Workflow#getWorkflowInfo()}. */
+    private final String cachedWorkflowId;
+
+    private final String cachedRunId;
+
+    /** Inbox wrapper so {@code mark_ready_to_ship} vs {@code mark_delivered} are not ambiguous. */
+    private static final class ReadyToShipMessage {
+      final OrderFulfillmentModels.SimpleSignal signal;
+
+      ReadyToShipMessage(OrderFulfillmentModels.SimpleSignal signal) {
+        this.signal = signal;
+      }
+    }
+
+    private static final class MarkDeliveredMessage {
+      final OrderFulfillmentModels.SimpleSignal signal;
+
+      MarkDeliveredMessage(OrderFulfillmentModels.SimpleSignal signal) {
+        this.signal = signal;
+      }
+    }
+
+    public WorkflowImpl() {
+      cachedWorkflowId = Workflow.getWorkflowInfo().getWorkflowId();
+      cachedRunId = Workflow.getWorkflowInfo().getRunId();
+      order.createdAtMillis = Workflow.currentTimeMillis();
+      OrderFulfillmentModels.ActionLogEntry created = new OrderFulfillmentModels.ActionLogEntry();
+      created.timestampMillis = order.createdAtMillis;
+      created.action = "Order Created";
+      created.operator = "System";
+      created.details =
+          String.format(
+              Locale.US, "Order %s created for %s", order.orderID, order.customerName);
+      actionLog.add(created);
+    }
+
+    @Override
+    public void run() {
+      // Main loop: block until a signal arrives in the inbox, dispatch it to update order state,
+      // then check if the order reached a terminal state (delivered, cancelled, or refunded).
+      while (!isTerminalState(order.status)) {
+        Workflow.await(() -> !inbox.isEmpty());
+        Object msg = inbox.removeFirst();
+        if (msg instanceof OrderFulfillmentModels.ApprovePaymentSignal) {
+          handleApprove((OrderFulfillmentModels.ApprovePaymentSignal) msg);
+        } else if (msg instanceof OrderFulfillmentModels.RejectPaymentSignal) {
+          handleReject((OrderFulfillmentModels.RejectPaymentSignal) msg);
+        } else if (msg instanceof ReadyToShipMessage) {
+          handleMarkReady(((ReadyToShipMessage) msg).signal);
+        } else if (msg instanceof MarkDeliveredMessage) {
+          handleMarkDelivered(((MarkDeliveredMessage) msg).signal);
+        } else if (msg instanceof OrderFulfillmentModels.ShipOrderSignal) {
+          handleShip((OrderFulfillmentModels.ShipOrderSignal) msg);
+        } else if (msg instanceof OrderFulfillmentModels.RefundSignal) {
+          handleRefund((OrderFulfillmentModels.RefundSignal) msg);
+        } else if (msg instanceof OrderFulfillmentModels.CancelOrderSignal) {
+          handleCancel((OrderFulfillmentModels.CancelOrderSignal) msg);
+        }
+      }
+    }
+
+    private void handleApprove(OrderFulfillmentModels.ApprovePaymentSignal signal) {
+      if (!STATUS_PENDING_PAYMENT.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_PAYMENT_APPROVED;
+      actionLog.add(
+          entry(
+              "Payment Approved",
+              getOperator(signal.operator),
+              String.format(Locale.US, "Payment of $%.2f approved", order.totalAmount)));
+    }
+
+    private void handleReject(OrderFulfillmentModels.RejectPaymentSignal signal) {
+      if (!STATUS_PENDING_PAYMENT.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_CANCELLED;
+      actionLog.add(
+          entry(
+              "Payment Rejected",
+              getOperator(signal.operator),
+              String.format(Locale.US, "Reason: %s", signal.reason)));
+    }
+
+    private void handleMarkReady(OrderFulfillmentModels.SimpleSignal signal) {
+      if (!STATUS_PAYMENT_APPROVED.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_READY_TO_SHIP;
+      actionLog.add(
+          entry(
+              "Marked Ready to Ship",
+              getOperator(signal.operator),
+              "Order prepared and ready for shipping"));
+    }
+
+    private void handleShip(OrderFulfillmentModels.ShipOrderSignal signal) {
+      if (!STATUS_READY_TO_SHIP.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_SHIPPED;
+      order.trackingNum = signal.trackingNumber;
+      order.carrier = signal.carrier;
+      actionLog.add(
+          entry(
+              "Order Shipped",
+              getOperator(signal.operator),
+              String.format(
+                  Locale.US,
+                  "Carrier: %s, Tracking: %s",
+                  signal.carrier,
+                  signal.trackingNumber)));
+    }
+
+    private void handleRefund(OrderFulfillmentModels.RefundSignal signal) {
+      if (!STATUS_PAYMENT_APPROVED.equals(order.status)
+          && !STATUS_SHIPPED.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_REFUNDED;
+      order.refundAmount = signal.amount;
+      order.refundReason = signal.reason;
+      actionLog.add(
+          entry(
+              "Refund Issued",
+              getOperator(signal.operator),
+              String.format(
+                  Locale.US, "Amount: $%.2f, Reason: %s", signal.amount, signal.reason)));
+    }
+
+    private void handleCancel(OrderFulfillmentModels.CancelOrderSignal signal) {
+      if (!STATUS_READY_TO_SHIP.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_CANCELLED;
+      actionLog.add(
+          entry(
+              "Order Cancelled",
+              getOperator(signal.operator),
+              String.format(Locale.US, "Reason: %s", signal.reason)));
+    }
+
+    private void handleMarkDelivered(OrderFulfillmentModels.SimpleSignal signal) {
+      if (!STATUS_SHIPPED.equals(order.status)) {
+        return;
+      }
+      order.status = STATUS_DELIVERED;
+      actionLog.add(
+          entry(
+              "Order Delivered",
+              getOperator(signal.operator),
+              "Package confirmed delivered to customer"));
+    }
+
+    private OrderFulfillmentModels.ActionLogEntry entry(String action, String operator, String details) {
+      OrderFulfillmentModels.ActionLogEntry e = new OrderFulfillmentModels.ActionLogEntry();
+      e.timestampMillis = Workflow.currentTimeMillis();
+      e.action = action;
+      e.operator = operator;
+      e.details = details;
+      return e;
+    }
+
+    @Override
+    public MarkdownFormattedResponse dashboardQuery() {
+      return new MarkdownFormattedResponse(makeOrderDashboard());
+    }
+
+    @Override
+    public void approvePayment(OrderFulfillmentModels.ApprovePaymentSignal signal) {
+      inbox.add(signal);
+    }
+
+    @Override
+    public void rejectPayment(OrderFulfillmentModels.RejectPaymentSignal signal) {
+      inbox.add(signal);
+    }
+
+    @Override
+    public void markReadyToShip(OrderFulfillmentModels.SimpleSignal signal) {
+      inbox.add(new ReadyToShipMessage(signal));
+    }
+
+    @Override
+    public void shipOrder(OrderFulfillmentModels.ShipOrderSignal signal) {
+      inbox.add(signal);
+    }
+
+    @Override
+    public void issueRefund(OrderFulfillmentModels.RefundSignal signal) {
+      inbox.add(signal);
+    }
+
+    @Override
+    public void cancelOrder(OrderFulfillmentModels.CancelOrderSignal signal) {
+      inbox.add(signal);
+    }
+
+    @Override
+    public void markDelivered(OrderFulfillmentModels.SimpleSignal signal) {
+      inbox.add(new MarkDeliveredMessage(signal));
+    }
+
+    private String makeOrderDashboard() {
+      String workflowId = cachedWorkflowId;
+      String runId = cachedRunId;
+      String createdAt = CREATED_FMT.format(Instant.ofEpochMilli(order.createdAtMillis));
+      String statusBadge = getStatusBadge(order.status);
+      String itemsTable = makeItemsTable(order);
+      String actionButtons = makeActionButtons(workflowId, runId, order);
+      String actionHistory = makeActionHistory(actionLog);
+
+      String trackingRow = "";
+      if (order.trackingNum != null && !order.trackingNum.isEmpty()) {
+        trackingRow =
+            "\n| **Tracking** | "
+                + order.carrier
+                + " - "
+                + order.trackingNum
+                + " |";
+      }
+      String refundRow = "";
+      if (order.refundAmount > 0) {
+        refundRow =
+            "\n| **Refund** | $"
+                + String.format(Locale.US, "%.2f", order.refundAmount)
+                + " |";
+      }
+
+      return "\n## 🛒 Order Dashboard\n\n"
+          + "> **Your admin panel** - manage orders directly from Cadence Web.\n\n"
+          + "---\n\n"
+          + "### ⚡ Available Actions\n"
+          + actionButtons
+          + "\n---\n\n"
+          + "### 📋 Order Details\n\n"
+          + "| Field | Value |\n"
+          + "|-------|-------|\n"
+          + "| **Order ID** | "
+          + order.orderID
+          + " |\n"
+          + "| **Customer** | "
+          + order.customerName
+          + " |\n"
+          + "| **Email** | "
+          + order.customerEmail
+          + " |\n"
+          + "| **Created** | "
+          + createdAt
+          + " |\n"
+          + "| **Status** | "
+          + statusBadge
+          + " |"
+          + trackingRow
+          + refundRow
+          + "\n\n"
+          + "### 📦 Order Items\n\n"
+          + "| Item | Qty | Price | Subtotal |\n"
+          + "|------|-----|-------|----------|\n"
+          + itemsTable
+          + "\n**Total: $"
+          + String.format(Locale.US, "%.2f", order.totalAmount)
+          + "**\n\n"
+          + "---\n\n"
+          + "### ⏱️ Action History\n\n"
+          + "| Timestamp | Action | Operator | Details |\n"
+          + "|-----------|--------|----------|---------|\n"
+          + actionHistory
+          + "\n---\n\n"
+          + "*Click query \"Run\" button again to see updated status after taking an action.*\n";
+    }
+
+    private static boolean isTerminalState(String status) {
+      return STATUS_DELIVERED.equals(status)
+          || STATUS_CANCELLED.equals(status)
+          || STATUS_REFUNDED.equals(status);
+    }
+
+    private static String getOperator(String operator) {
+      if (operator == null || operator.isEmpty()) {
+        return "ops-user";
+      }
+      return operator;
+    }
+
+    private static String getStatusBadge(String status) {
+      switch (status) {
+        case STATUS_PENDING_PAYMENT:
+          return "🟡 **Pending Payment**";
+        case STATUS_PAYMENT_APPROVED:
+          return "🟢 **Payment Approved**";
+        case STATUS_READY_TO_SHIP:
+          return "📦 **Ready to Ship**";
+        case STATUS_SHIPPED:
+          return "🚚 **Shipped**";
+        case STATUS_DELIVERED:
+          return "✅ **Delivered**";
+        case STATUS_CANCELLED:
+          return "❌ **Cancelled**";
+        case STATUS_REFUNDED:
+          return "💰 **Refunded**";
+        default:
+          return status;
+      }
+    }
+
+    private static String makeItemsTable(OrderFulfillmentModels.Order order) {
+      StringBuilder table = new StringBuilder();
+      for (OrderFulfillmentModels.OrderItem item : order.items) {
+        double subtotal = item.quantity * item.price;
+        table.append(
+            String.format(
+                Locale.US,
+                "| %s | %d | $%.2f | $%.2f |\n",
+                item.name, item.quantity, item.price, subtotal));
+      }
+      return table.toString();
+    }
+
+    private static String makeActionHistory(List<OrderFulfillmentModels.ActionLogEntry> actionLog) {
+      StringBuilder history = new StringBuilder();
+      for (OrderFulfillmentModels.ActionLogEntry entry : actionLog) {
+        String t = HISTORY_TIME_FMT.format(Instant.ofEpochMilli(entry.timestampMillis));
+        history
+            .append("| ")
+            .append(t)
+            .append(" | ")
+            .append(entry.action)
+            .append(" | ")
+            .append(entry.operator)
+            .append(" | ")
+            .append(entry.details)
+            .append(" |\n");
+      }
+      return history.toString();
+    }
+
+    /**
+     * Key to the "state-driven UI" pattern: the set of rendered Markdoc buttons depends on the
+     * current order status. For example, shipping options only appear when the order is
+     * {@code ready_to_ship}, and approval buttons only appear when {@code pending_payment}.
+     */
+    private static String makeActionButtons(
+        String workflowId, String runId, OrderFulfillmentModels.Order order) {
+      switch (order.status) {
+        case STATUS_PENDING_PAYMENT:
+          return "\n**Payment Review:**\n\n"
+              + sig(
+                  "approve_payment",
+                  "✓ Approve Payment",
+                  workflowId,
+                  runId,
+                  "{\"operator\":\"ops-user\"}")
+              + sig(
+                  "reject_payment",
+                  "✗ Reject: Policy Violation",
+                  workflowId,
+                  runId,
+                  "{\"reason\":\"Policy Violation\",\"operator\":\"ops-user\"}")
+              + sig(
+                  "reject_payment",
+                  "✗ Reject: Fraud Suspected",
+                  workflowId,
+                  runId,
+                  "{\"reason\":\"Fraud Suspected\",\"operator\":\"ops-user\"}")
+              + sig(
+                  "reject_payment",
+                  "✗ Reject: Customer Request",
+                  workflowId,
+                  runId,
+                  "{\"reason\":\"Customer Request\",\"operator\":\"ops-user\"}")
+              + "\n";
+
+        case STATUS_PAYMENT_APPROVED:
+          return "\n**Fulfillment Actions:**\n\n"
+              + sig(
+                  "mark_ready_to_ship",
+                  "📦 Mark Ready to Ship",
+                  workflowId,
+                  runId,
+                  "{\"operator\":\"ops-user\"}")
+              + "\n**Refund Options:**\n\n"
+              + sig(
+                  "issue_refund",
+                  "💰 Full Refund ($"
+                      + String.format(Locale.US, "%.2f", order.totalAmount)
+                      + ")",
+                  workflowId,
+                  runId,
+                  String.format(
+                      Locale.US,
+                      "{\"amount\":%.2f,\"reason\":\"Full refund requested\",\"operator\":\"ops-user\"}",
+                      order.totalAmount))
+              + sig(
+                  "issue_refund",
+                  "💰 Partial Refund (50%)",
+                  workflowId,
+                  runId,
+                  String.format(
+                      Locale.US,
+                      "{\"amount\":%.2f,\"reason\":\"Partial refund - customer goodwill\",\"operator\":\"ops-user\"}",
+                      order.totalAmount / 2))
+              + "\n";
+
+        case STATUS_READY_TO_SHIP:
+          return "\n**Shipping Options:**\n\n"
+              + sig(
+                  "ship_order",
+                  "🚚 Ship via UPS",
+                  workflowId,
+                  runId,
+                  "{\"trackingNumber\":\"1Z999AA10123456784\",\"carrier\":\"UPS\",\"operator\":\"ops-user\"}")
+              + sig(
+                  "ship_order",
+                  "🚚 Ship via FedEx",
+                  workflowId,
+                  runId,
+                  "{\"trackingNumber\":\"794644790126\",\"carrier\":\"FedEx\",\"operator\":\"ops-user\"}")
+              + sig(
+                  "ship_order",
+                  "🚚 Ship via USPS",
+                  workflowId,
+                  runId,
+                  "{\"trackingNumber\":\"9400111899223456789012\",\"carrier\":\"USPS\",\"operator\":\"ops-user\"}")
+              + "\n**Cancel Order:**\n\n"
+              + sig(
+                  "cancel_order",
+                  "❌ Cancel Order",
+                  workflowId,
+                  runId,
+                  "{\"reason\":\"Cancelled before shipping\",\"operator\":\"ops-user\"}")
+              + "\n";
+
+        case STATUS_SHIPPED:
+          return "\n**Delivery Confirmation:**\n\n"
+              + sig(
+                  "mark_delivered",
+                  "✅ Mark as Delivered",
+                  workflowId,
+                  runId,
+                  "{\"operator\":\"ops-user\"}")
+              + "\n**Refund Options:**\n\n"
+              + sig(
+                  "issue_refund",
+                  "💰 Full Refund ($"
+                      + String.format(Locale.US, "%.2f", order.totalAmount)
+                      + ")",
+                  workflowId,
+                  runId,
+                  String.format(
+                      Locale.US,
+                      "{\"amount\":%.2f,\"reason\":\"Full refund requested\",\"operator\":\"ops-user\"}",
+                      order.totalAmount))
+              + "\n";
+
+        default:
+          return "\n*No actions available - order has been completed.*\n";
+      }
+    }
+
+    /** Builds a Markdoc {@code {%- signal -%}} tag targeting this workflow execution. */
+    private static String sig(
+        String signalName, String label, String workflowId, String runId, String jsonInput) {
+      return "{% signal \n"
+          + "\tsignalName=\""
+          + signalName
+          + "\" \n"
+          + "\tlabel=\""
+          + label
+          + "\"\n"
+          + "\tdomain=\""
+          + DOMAIN
+          + "\"\n"
+          + "\tcluster=\""
+          + CLUSTER
+          + "\"\n"
+          + "\tworkflowId=\""
+          + workflowId
+          + "\"\n"
+          + "\trunId=\""
+          + runId
+          + "\"\n"
+          + "\tinput="
+          + jsonInput
+          + "\n/%}\n";
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentWorkflow.java
+++ b/src/main/java/com/uber/cadence/samples/query/OrderFulfillmentWorkflow.java
@@ -107,10 +107,8 @@ public final class OrderFulfillmentWorkflow {
      */
     private final ArrayDeque<Object> inbox = new ArrayDeque<>();
 
-    /** Cached in constructor (workflow thread); queries must not call {@link Workflow#getWorkflowInfo()}. */
-    private final String cachedWorkflowId;
-
-    private final String cachedRunId;
+    private final String cachedWorkflowId = "";
+    private final String cachedRunId = "";
 
     /** Inbox wrapper so {@code mark_ready_to_ship} vs {@code mark_delivered} are not ambiguous. */
     private static final class ReadyToShipMessage {

--- a/src/main/java/com/uber/cadence/samples/query/QueryConstants.java
+++ b/src/main/java/com/uber/cadence/samples/query/QueryConstants.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import com.uber.cadence.samples.common.SampleConstants;
+
+/** Shared settings for Custom Workflow Controls (Markdoc query) samples. */
+public final class QueryConstants {
+
+  private QueryConstants() {}
+
+  /** Task list used by {@link QueryWorker} and all query sample starters. */
+  public static final String TASK_LIST = "query";
+
+  /** Cadence domain; must match Markdoc {% signal %} / {% start %} attributes. */
+  public static final String DOMAIN = SampleConstants.DOMAIN;
+
+  /**
+   * Cluster name for Cadence Web Markdoc controls. Must match the cluster configured in your
+   * Cadence Web deployment (v4.0.14+).
+   */
+  public static final String CLUSTER = "cluster0";
+
+  /** Registered workflow type for {@link MarkdownQueryWorkflow}. */
+  public static final String MARKDOWN_QUERY_WORKFLOW_TYPE = "MarkdownQueryWorkflow";
+
+  /**
+   * Markdoc {@code signalName} for {@link MarkdownQueryWorkflow.WorkflowIface#complete(Object)}.
+   *
+   * <p>The Cadence Java SDK registers workflow signals as {@code InterfaceName::methodName} (here
+   * {@code WorkflowIface::complete}). Cadence Web sends the raw string from the Markdoc template,
+   * so the {@code signalName} attribute in the markdown must use this qualified form.
+   */
+  public static final String MARKDOWN_QUERY_COMPLETE_SIGNAL_MARKDOC = "WorkflowIface::complete";
+
+  /** Registered workflow type for {@link LunchVoteWorkflow}. */
+  public static final String LUNCH_VOTE_WORKFLOW_TYPE = "LunchVoteWorkflow";
+
+  /** Registered workflow type for {@link OrderFulfillmentWorkflow}. */
+  public static final String ORDER_FULFILLMENT_WORKFLOW_TYPE = "OrderFulfillmentWorkflow";
+}

--- a/src/main/java/com/uber/cadence/samples/query/QueryConstants.java
+++ b/src/main/java/com/uber/cadence/samples/query/QueryConstants.java
@@ -40,7 +40,7 @@ public final class QueryConstants {
   public static final String MARKDOWN_QUERY_WORKFLOW_TYPE = "MarkdownQueryWorkflow";
 
   /**
-   * Markdoc {@code signalName} for {@link MarkdownQueryWorkflow.WorkflowIface#complete(Object)}.
+   * Markdoc {@code signalName} for {@link MarkdownQueryWorkflow.WorkflowIface#complete(boolean)}.
    *
    * <p>The Cadence Java SDK registers workflow signals as {@code InterfaceName::methodName} (here
    * {@code WorkflowIface::complete}). Cadence Web sends the raw string from the Markdoc template,

--- a/src/main/java/com/uber/cadence/samples/query/QuerySampleSupport.java
+++ b/src/main/java/com/uber/cadence/samples/query/QuerySampleSupport.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.internal.compatibility.Thrift2ProtoAdapter;
+import com.uber.cadence.internal.compatibility.proto.serviceclient.IGrpcServiceStubs;
+import com.uber.cadence.samples.common.SampleConstants;
+
+/** Shared client factory and friendly errors for query sample starters. */
+final class QuerySampleSupport {
+
+  private QuerySampleSupport() {}
+
+  static WorkflowClient newWorkflowClient() {
+    return WorkflowClient.newInstance(
+        new Thrift2ProtoAdapter(IGrpcServiceStubs.newInstance()),
+        WorkflowClientOptions.newBuilder().setDomain(SampleConstants.DOMAIN).build());
+  }
+
+  /**
+   * @return true if {@code t} was a missing-domain error and a hint was printed (caller should
+   *     exit).
+   */
+  static boolean printHintIfDomainMissing(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      String m = c.getMessage();
+      if (m != null && m.contains("Domain") && m.contains("does not exist")) {
+        System.err.println();
+        System.err.println("Cadence reported that the domain \"" + SampleConstants.DOMAIN + "\" does not exist.");
+        System.err.println("Register it once against your cluster, then run this starter again:");
+        System.err.println();
+        System.err.println(
+            "  ./gradlew -q execute -PmainClass=com.uber.cadence.samples.common.RegisterDomain");
+        System.err.println();
+        System.err.println("Or with Cadence CLI:");
+        System.err.println("  cadence --domain " + SampleConstants.DOMAIN + " domain register");
+        System.err.println();
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/QueryWorker.java
+++ b/src/main/java/com/uber/cadence/samples/query/QueryWorker.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.samples.query;
+
+import static com.uber.cadence.samples.query.QueryConstants.TASK_LIST;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.internal.compatibility.Thrift2ProtoAdapter;
+import com.uber.cadence.internal.compatibility.proto.serviceclient.IGrpcServiceStubs;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactory;
+import com.uber.cadence.samples.common.SampleConstants;
+
+/**
+ * Hosts all Custom Workflow Controls sample workflows and {@link
+ * MarkdownQueryWorkflow.MarkdownQueryActivities}. Run this before starting any workflow in {@link
+ * QueryConstants#TASK_LIST}.
+ */
+public final class QueryWorker {
+
+  private QueryWorker() {}
+
+  public static void main(String[] args) {
+    WorkflowClient workflowClient =
+        WorkflowClient.newInstance(
+            new Thrift2ProtoAdapter(IGrpcServiceStubs.newInstance()),
+            WorkflowClientOptions.newBuilder().setDomain(SampleConstants.DOMAIN).build());
+
+    WorkerFactory factory = WorkerFactory.newInstance(workflowClient);
+    Worker worker = factory.newWorker(TASK_LIST);
+
+    // Registration scans each interface for @WorkflowMethod, @QueryMethod, and @SignalMethod
+    // annotations and registers handlers. Signal names default to "InterfaceName::methodName"
+    // unless @SignalMethod(name=...) overrides it.
+    worker.registerWorkflowImplementationTypes(
+        MarkdownQueryWorkflow.WorkflowImpl.class,
+        LunchVoteWorkflow.WorkflowImpl.class,
+        OrderFulfillmentWorkflow.WorkflowImpl.class);
+    worker.registerActivitiesImplementations(new MarkdownQueryWorkflow.MarkdownQueryActivitiesImpl());
+
+    // Non-blocking: the worker threads poll the task list in the background and this process
+    // stays alive until killed.
+    factory.start();
+    System.out.println("QueryWorker listening on task list \"" + TASK_LIST + "\" (domain \""
+        + SampleConstants.DOMAIN
+        + "\").");
+  }
+}

--- a/src/main/java/com/uber/cadence/samples/query/QueryWorker.java
+++ b/src/main/java/com/uber/cadence/samples/query/QueryWorker.java
@@ -20,9 +20,6 @@ package com.uber.cadence.samples.query;
 import static com.uber.cadence.samples.query.QueryConstants.TASK_LIST;
 
 import com.uber.cadence.client.WorkflowClient;
-import com.uber.cadence.client.WorkflowClientOptions;
-import com.uber.cadence.internal.compatibility.Thrift2ProtoAdapter;
-import com.uber.cadence.internal.compatibility.proto.serviceclient.IGrpcServiceStubs;
 import com.uber.cadence.worker.Worker;
 import com.uber.cadence.worker.WorkerFactory;
 import com.uber.cadence.samples.common.SampleConstants;
@@ -37,10 +34,7 @@ public final class QueryWorker {
   private QueryWorker() {}
 
   public static void main(String[] args) {
-    WorkflowClient workflowClient =
-        WorkflowClient.newInstance(
-            new Thrift2ProtoAdapter(IGrpcServiceStubs.newInstance()),
-            WorkflowClientOptions.newBuilder().setDomain(SampleConstants.DOMAIN).build());
+    WorkflowClient workflowClient = QuerySampleSupport.newWorkflowClient();
 
     WorkerFactory factory = WorkerFactory.newInstance(workflowClient);
     Worker worker = factory.newWorker(TASK_LIST);

--- a/src/main/java/com/uber/cadence/samples/query/README.md
+++ b/src/main/java/com/uber/cadence/samples/query/README.md
@@ -1,0 +1,78 @@
+# Custom Workflow Controls (Markdoc query samples)
+
+These workflows return **formatted markdown** from workflow queries so [Cadence Web](https://github.com/cadence-workflow/cadence-web) can render **Custom Workflow Controls**: Markdoc tags such as `{% signal %}` and `{% start %}` become buttons that signal this workflow or start a new one.
+
+**Requires Cadence Web v4.0.14 or newer** for markdown rendering and interactive controls.
+
+Constants used in the Markdoc snippets (`domain`, `taskList`, `cluster`) match [`QueryConstants.java`](QueryConstants.java): domain **`samples-domain`**, task list **`query`**, cluster **`cluster0`**.
+
+## Prerequisites
+
+1. Cadence server running (e.g. Docker Compose from the [Cadence repo](https://github.com/uber/cadence)).
+2. **Cadence Web v4.0.14+** connected to the same cluster.
+3. From the repo root, build: `./gradlew build`
+
+### Register the domain (required once per cluster)
+
+Starters use domain **`samples-domain`**. If you see `Domain samples-domain does not exist`, register it **before** starting workflows:
+
+```bash
+./gradlew -q execute -PmainClass=com.uber.cadence.samples.common.RegisterDomain
+```
+
+Or with the Cadence CLI:
+
+```bash
+cadence --domain samples-domain domain register
+```
+
+See also the root [README.md](../../../../../../../../README.md).
+
+## Run the worker (terminal 1)
+
+Leave this process running:
+
+```bash
+cd /path/to/cadence-java-samples
+./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.QueryWorker
+```
+
+## Start a workflow (terminal 2)
+
+Run **one** of the starters (each starts a new workflow execution on task list `query`):
+
+**Markdown Query** — query name `Signal` in the Web UI:
+
+```bash
+./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.MarkdownQueryStarter
+```
+
+**Lunch Vote** — query name `options`:
+
+```bash
+./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.LunchVoteStarter
+```
+
+**Order Fulfillment (ops dashboard)** — query name `dashboard`:
+
+```bash
+./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.OrderFulfillmentStarter
+```
+
+## Use Cadence Web
+
+1. Open the UI (e.g. [http://localhost:8088](http://localhost:8088)) and select domain **`samples-domain`**.
+2. Open the workflow run you started.
+3. Open the **Query** tab.
+4. Choose the query type (**`Signal`**, **`options`**, or **`dashboard`**) and run it.
+5. Use the rendered buttons; re-run the query to refresh markdown after signals.
+
+## Source layout
+
+| Sample | Workflow interface / impl | Query name |
+|--------|---------------------------|------------|
+| Markdoc + activity | [`MarkdownQueryWorkflow.java`](MarkdownQueryWorkflow.java) | `Signal` |
+| Lunch voting | [`LunchVoteWorkflow.java`](LunchVoteWorkflow.java) | `options` |
+| Order dashboard | [`OrderFulfillmentWorkflow.java`](OrderFulfillmentWorkflow.java) | `dashboard` |
+
+See also: [Workflow queries with formatted data](https://cadenceworkflow.io/docs/concepts/workflow-queries-formatted-data) (conceptual overview).

--- a/src/main/java/com/uber/cadence/samples/query/README.md
+++ b/src/main/java/com/uber/cadence/samples/query/README.md
@@ -1,5 +1,7 @@
 # Custom Workflow Controls (Markdoc query samples)
 
+> **Concept overview:** [Workflow queries with formatted data](https://cadenceworkflow.io/docs/concepts/workflow-queries-formatted-data)
+
 These workflows return **formatted markdown** from workflow queries so [Cadence Web](https://github.com/cadence-workflow/cadence-web) can render **Custom Workflow Controls**: Markdoc tags such as `{% signal %}` and `{% start %}` become buttons that signal this workflow or start a new one.
 
 **Requires Cadence Web v4.0.14 or newer** for markdown rendering and interactive controls.
@@ -75,4 +77,3 @@ Run **one** of the starters (each starts a new workflow execution on task list `
 | Lunch voting | [`LunchVoteWorkflow.java`](LunchVoteWorkflow.java) | `options` |
 | Order dashboard | [`OrderFulfillmentWorkflow.java`](OrderFulfillmentWorkflow.java) | `dashboard` |
 
-See also: [Workflow queries with formatted data](https://cadenceworkflow.io/docs/concepts/workflow-queries-formatted-data) (conceptual overview).


### PR DESCRIPTION
**Which sample(s) or area?**

New `com.uber.cadence.samples.query` package (12 new files + root README update).

**What changed?**

Added three workflow samples demonstrating [Custom Workflow Controls](https://cadenceworkflow.io/docs/concepts/workflow-queries-formatted-data) — a Cadence Web v4.0.14+ feature where `@QueryMethod` responses return interactive markdown rendered via Markdoc. `{% signal %}` and `{% start %}` tags become buttons that signal running workflows or start new ones directly from the Web UI.

| Sample | Query name | What it demonstrates |
|--------|-----------|----------------------|
| **MarkdownQueryWorkflow** | `Signal` | Signal & start-workflow buttons, wait-activity loop |
| **LunchVoteWorkflow** | `options` | Interactive voting via signals, dynamic vote table rendering |
| **OrderFulfillmentWorkflow** | `dashboard` | State-machine ops panel with context-sensitive action buttons |

Supporting files:
- `QueryConstants` — shared task list, domain, cluster, workflow type names
- `MarkdownFormattedResponse` — POJO for the JSON contract Cadence Web expects
- `QueryWorker` — unified worker registering all three workflows
- `MarkdownQueryStarter` / `LunchVoteStarter` / `OrderFulfillmentStarter` — per-workflow starters
- `QuerySampleSupport` — shared client factory with domain-missing error hints
- Package-level `README.md` with prerequisites and run instructions

**Why?**

Provides Java reference implementations for Custom Workflow Controls so Java developers can see how to build interactive Markdoc query responses without needing to reference the Go samples.

**How did you test it?**
Prerequisites: Cadence server running locally, Cadence Web **v4.0.14+** connected.
```bash
# Build
./gradlew build
# Register domain (once per cluster)
./gradlew -q execute -PmainClass=com.uber.cadence.samples.common.RegisterDomain
# Start the worker (leave running in terminal 1)
./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.QueryWorker
# Start a workflow (terminal 2 — pick one)
./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.MarkdownQueryStarter
./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.LunchVoteStarter
./gradlew -q execute -PmainClass=com.uber.cadence.samples.query.OrderFulfillmentStart
```
**Potential risks**

- Requires Cadence Web **v4.0.14+**; older versions will display raw JSON instead of rendered markdown.
- The Java SDK registers signal names as `InterfaceName::methodName` by default (e.g. `WorkflowIface::complete`). Markdoc templates use this qualified form. This is documented in `QueryConstants` and the package README.

**Release notes**

New sample: Custom Workflow Controls (Markdoc query responses) — three workflows demonstrating interactive markdown queries with signal and start-workflow buttons in Cadence Web.

**Documentation Changes**

- Root `README.md` updated with Custom Workflow Controls section.
- New `src/main/java/com/uber/cadence/samples/query/README.md` with prerequisites, run commands, and Cadence Web usage steps.
