### PR TITLE
chore: add Snyk security scanning and dependency review workflows

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -1,0 +1,50 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Snyk to check for vulnerabilities
+        if: github.event_name == 'pull_request'
+        uses: snyk/actions/gradle-jdk8@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high --sarif-file-output=snyk.sarif
+      - name: Upload result to GitHub Code Scanning
+        if: github.event_name == 'pull_request'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
+      - name: Monitor on default branch
+        if: github.event_name == 'push'
+        uses: snyk/actions/gradle-jdk8@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        continue-on-error: true
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always


### PR DESCRIPTION
## Summary

- Adds Snyk vulnerability scanning on PRs (advisory, non-blocking) with results uploaded to the GitHub Security tab via SARIF
- Runs `snyk monitor` on pushes to the default branch to register a dependency snapshot in Snyk for ongoing tracking
- Adds `dependency-review-action` on PRs to surface newly introduced dependencies and any known vulnerabilities in them

## Prerequisites

`SNYK_TOKEN` must be added to this repository's GitHub Actions secrets (Settings → Secrets and variables → Actions) before the Snyk jobs will succeed.